### PR TITLE
아키텍처 개선: 보안/인가/토큰/운영/관측 5단계 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     // FCM
     implementation 'com.google.firebase:firebase-admin:9.5.0'
 
+    // Actuator + Prometheus
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // 유틸
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.apache.commons:commons-lang3:3.18.0")

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // 구조화 로깅 (JSON) - 운영 환경
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+
     // 유틸
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.apache.commons:commons-lang3:3.18.0")

--- a/doc/architecture-visualization.md
+++ b/doc/architecture-visualization.md
@@ -1,0 +1,915 @@
+# 단디온나 백엔드 아키텍처 시각화
+
+> 본 문서는 현재(AS-IS) 아키텍처와 개선 목표(TO-BE) 아키텍처를 Mermaid 다이어그램으로 시각화합니다.
+
+---
+
+## 1. 시스템 전체 구조 (AS-IS)
+
+```mermaid
+flowchart TB
+    subgraph Clients["🖥️ 클라이언트"]
+        OwnerApp["사장님 앱/웹"]
+        ConsumerApp["소비자 앱/웹"]
+    end
+
+    subgraph LB["로드밸런서 / 리버스 프록시"]
+        Gateway["(미구현)"]
+    end
+
+    subgraph SpringBoot["Spring Boot 애플리케이션"]
+        subgraph Security["보안 계층"]
+            JweAuthFilter["JweAuthFilter\n(Bearer 토큰 추출)"]
+            SecurityConfig["SecurityConfig\n(필터 체인)"]
+            JweTokenService["JweTokenService\n(토큰 발급/검증)"]
+            TokenBlacklist["TokenBlacklistService\n(Redis 블랙리스트)"]
+        end
+
+        subgraph Controllers["컨트롤러 계층"]
+            AuthCtrl["AuthController\n/api/v1/auth/**"]
+            StoreCtrl["StoreController\n/api/v1/stores/**"]
+            StoreConsCtrl["StoreConsumerController\n/api/v1/stores/{id}/no-show-posts"]
+            MenuCtrl["MenuController\n/api/v1/owner/menus/**"]
+            NoShowPostCtrl["NoShowPostController\n/api/v1/owner/no-show-posts/**"]
+            NoShowOrderCtrl["NoShowOrderController\n/api/v1/owner/orders/**"]
+            ConsumerOrderCtrl["NoShowOrderConsumerController\n/api/v1/orders"]
+            SalesCtrl["OwnerSalesController\n/api/v1/owner/sales/**"]
+            SalesExportCtrl["OwnerSalesExportController\n/api/v1/owner/sales/export/**"]
+            HomeCtrl["HomeController\n/api/v1/home/**"]
+            FavCtrl["FavoriteController\n/api/v1/favorites"]
+            PushCtrl["PushTokenController\n/api/v1/push/tokens"]
+            UploadCtrls["StoreUploadController\nMenuUploadController\n/api/v1/**/uploads/**"]
+        end
+
+        subgraph Services["서비스 계층"]
+            AuthSvc["AuthService"]
+            StoreSvc["StoreService"]
+            StoreConsSvc["StoreConsumerService"]
+            MenuSvc["MenuService"]
+            MenuPermSvc["MenuPermissionService"]
+            NoShowPostSvc["NoShowPostService"]
+            NoShowOrderSvc["NoShowOrderService"]
+            ConsumerOrderSvc["NoShowOrderConsumerService"]
+            SalesSvc["OwnerSalesService"]
+            ExportJobSvc["ExportJobService"]
+            HomeSvc["HomeService"]
+            HomeStoreSvc["HomeStoreService"]
+            FavSvc["FavoriteService"]
+            FavNotiSvc["FavoriteNotificationService"]
+            PushTokenSvc["PushTokenService"]
+            FcmSvc["FcmNotificationService"]
+            UploadSvc["UploadService"]
+            NotiEnqSvc["NotificationEnqueueService"]
+        end
+
+        subgraph AsyncWorkers["비동기 워커"]
+            NotiWorker["NotificationDispatchWorker\n(Redis Stream 소비)"]
+            NotiRunner["NotificationWorkerRunner"]
+            ExportWorker["ExportJobDispatchWorker\n(Redis Stream 소비)"]
+            ExportRunner["ExportJobWorkerRunner"]
+        end
+
+        subgraph Repositories["리포지토리 계층"]
+            UserRepo["UserRepository"]
+            StoreRepo["StoreRepository"]
+            MenuRepo["MenuRepository"]
+            NoShowPostRepo["NoShowPostRepository"]
+            NoShowPostHistRepo["NoShowPostHistoryRepository"]
+            NoShowOrderRepo["NoShowOrderRepository"]
+            NoShowOrderItemRepo["NoShowOrderItemRepository"]
+            FavRepo["FavoriteRepository"]
+            PushTokenRepo["PushTokenRepository"]
+            NotiRepo["NotificationRepository"]
+            NotiTargetRepo["NotificationTargetRepository"]
+            ExportJobRepo["ExportJobRepository"]
+            ConsumerProfileRepo["ConsumerProfileRepository"]
+            OwnerProfileRepo["OwnerProfileRepository"]
+        end
+
+        subgraph Common["공통 모듈"]
+            ApiResponse["ApiResponse / ErrorCode"]
+            BaseEntity["BaseEntity (audit)"]
+            GlobalExHandler["GlobalExceptionHandler"]
+            SecurityUtils["SecurityUtils"]
+            BizException["BusinessException"]
+        end
+    end
+
+    subgraph Infra["인프라"]
+        DB[("PostgreSQL\n+ PostGIS")]
+        Redis[("Redis\nBlacklist + Streams")]
+        S3[("S3 / MinIO\nPresigned URL")]
+        FCM[("Firebase Cloud\nMessaging")]
+    end
+
+    Clients -->|"HTTPS + JWT"| SecurityConfig
+    SecurityConfig --> JweAuthFilter
+    JweAuthFilter --> TokenBlacklist
+    JweAuthFilter --> JweTokenService
+    JweAuthFilter --> Controllers
+
+    Controllers --> Services
+    Services --> Repositories
+    Repositories --> DB
+
+    TokenBlacklist --> Redis
+    NotiEnqSvc --> Redis
+    ExportJobSvc --> Redis
+
+    Redis --> NotiWorker
+    Redis --> ExportWorker
+    NotiWorker --> FCM
+    ExportWorker --> S3
+
+    UploadSvc --> S3
+    FcmSvc --> FCM
+
+    FCM -.->|"Push"| Clients
+```
+
+---
+
+## 2. 패키지 구조 & 의존 관계 (AS-IS)
+
+```mermaid
+flowchart LR
+    subgraph config["config"]
+        Security["Security/\nSecurityConfig\nJweAuthFilter\nJweTokenService\nJwtProps\nSecurityBeans"]
+        Aws["Aws/\nAwsConfig\nMinioHttpClientConfig"]
+        Fcm["Fcm/\nFirebaseConfig"]
+    end
+
+    subgraph auth["auth"]
+        AuthCtrl["controller/\nAuthController"]
+        AuthSvc["service/\nAuthService\nTokenBlacklistService"]
+        AuthEntity["entity/\nUser, UserRole"]
+        AuthRepo["repository/\nUserRepository"]
+        AuthDto["dto/\nLogin*, Logout*\nRefresh*, SignUp*"]
+    end
+
+    subgraph store["store"]
+        StoreCtrl2["controller/\nStoreController\nStoreConsumerController"]
+        StoreSvc2["service/\nStoreService\nStoreConsumerService"]
+        StoreEntity["entity/\nStore, ImageStatus"]
+        StoreRepo2["repository/\nStoreRepository"]
+    end
+
+    subgraph menu["menu"]
+        MenuCtrl2["controller/\nMenuController"]
+        MenuSvc2["service/\nMenuService\nMenuPermissionService"]
+        MenuEntity["entity/\nMenu"]
+        MenuRepo2["repository/\nMenuRepository"]
+    end
+
+    subgraph noshow_post["noshow_post"]
+        NspCtrl["controller/\nNoShowPostController"]
+        NspSvc["service/\nNoShowPostService"]
+        NspEntity["entity/\nNoShowPost\nNoShowPostHistory\nNoShowPostStatus"]
+        NspRepo["repository/\nNoShowPost*Repository"]
+    end
+
+    subgraph noshow_order["noshow_order"]
+        NsoCtrl["controller/\nNoShowOrderController\nConsumerController\nSalesController\nSalesExportController"]
+        NsoSvc["service/\nNoShowOrderService\nConsumerService\nOwnerSalesService"]
+        NsoEntity["entity/\nNoShowOrder\nNoShowOrderItem\nNoShowOrderStatus\nNoShowPaymentStatus"]
+        NsoRepo["repository/\nNoShowOrder*Repository"]
+    end
+
+    subgraph favorite["favorite"]
+        FavCtrl2["controller/\nFavoriteController"]
+        FavSvc2["service/\nFavoriteService\nFavoriteNotificationService"]
+        FavEntity["entity/\nFavorite, FavoriteId"]
+        FavRepo2["repository/\nFavoriteRepository"]
+    end
+
+    subgraph fcm_pkg["fcm"]
+        FcmCtrl["controller/\nPushTokenController"]
+        FcmSvc2["service/\nPushTokenService\nFcmNotificationService"]
+        FcmEntity["entity/\nPushToken, Platform"]
+        FcmRepo["repository/\nPushTokenRepository"]
+    end
+
+    subgraph home_pkg["home"]
+        HomeCtrl2["controller/\nHomeController"]
+        HomeSvc2["service/\nHomeService\nHomeStoreService"]
+    end
+
+    subgraph s3_pkg["s3"]
+        S3Ctrl["controller/\nStoreUploadController\nMenuUploadController"]
+        S3Svc["service/\nUploadService"]
+    end
+
+    subgraph notification["notification"]
+        NotiSvc["service/\nNotificationEnqueueService"]
+        NotiWorker2["worker/\nDispatchWorker\nWorkerRunner"]
+        NotiProducer["producer/\nNotificationProducer"]
+        NotiEntity["entity/\nNotification\nNotificationTarget"]
+        NotiRepos["repository/\nNotification*Repository"]
+    end
+
+    subgraph export_job["export_job"]
+        ExportSvc["service/\nExportJobService"]
+        ExportWorker2["worker/\nDispatchWorker\nWorkerRunner"]
+        ExportProducer["producer/\nExportJobProducer"]
+        ExportEntity["entity/\nExportJob\nExportJobStatus"]
+        ExportRepos["repository/\nExportJobRepository"]
+    end
+
+    %% 핵심 의존 흐름
+    auth -->|"토큰 발급"| Security
+    NspSvc -->|"알림 트리거"| FavSvc2
+    FavSvc2 -->|"FCM 전송"| FcmSvc2
+    NsoSvc -->|"주문 알림"| FcmSvc2
+    NotiSvc -->|"Redis Stream"| NotiWorker2
+    NotiWorker2 -->|"FCM"| FcmSvc2
+    ExportSvc -->|"Redis Stream"| ExportWorker2
+    HomeSvc2 -->|"매장 조회"| store
+    HomeSvc2 -->|"주문 조회"| noshow_order
+    S3Ctrl -->|"이미지"| store
+    S3Ctrl -->|"이미지"| menu
+```
+
+---
+
+## 3. 데이터 흐름 (핵심 시나리오)
+
+### 3-1. 인증 흐름
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant F as JweAuthFilter
+    participant BL as TokenBlacklistService
+    participant TS as JweTokenService
+    participant SC as SecurityContext
+    participant Ctrl as Controller
+
+    C->>F: HTTP + Authorization: Bearer <JWE>
+    F->>BL: isBlacklisted(token)?
+    alt 블랙리스트
+        BL-->>F: true
+        F-->>C: 인증 없이 체인 진행 → 401
+    else 유효
+        BL-->>F: false
+        F->>TS: parseClaims(token)
+        TS-->>F: Claims(userId, role, exp)
+        F->>SC: setAuthentication(token)
+        F->>Ctrl: chain.doFilter()
+        Ctrl->>SC: getAuthentication()
+        Ctrl-->>C: 200 응답
+    end
+```
+
+### 3-2. 노쇼 주문 & 알림 흐름
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Consumer as 소비자 앱
+    participant API as OrderConsumerController
+    participant Svc as ConsumerOrderService
+    participant DB as PostgreSQL
+    participant FCM as FcmNotificationService
+    participant Owner as 사장님 기기
+
+    Consumer->>API: POST /api/v1/orders
+    API->>Svc: createOrder(request)
+    Svc->>DB: 노쇼글 조회 + 비관적 잠금
+    Svc->>DB: 재고 차감 & 주문 생성
+    Svc->>DB: 주문 아이템 스냅샷 저장
+    Svc->>FCM: 사장님 기기로 푸시 알림 전송
+    FCM->>Owner: "[노쇼 주문] 00님이 주문했어요"
+    Svc-->>API: OrderCreateResponse
+    API-->>Consumer: 200 + 주문번호/UUID
+```
+
+### 3-3. 이미지 업로드 흐름
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as 클라이언트
+    participant API as UploadController
+    participant Svc as UploadService
+    participant S3 as S3/MinIO
+
+    Client->>API: POST /uploads/presign (fileName, contentType)
+    API->>Svc: presign(target, referenceId, request)
+    Svc->>S3: S3Presigner.presignPutObject()
+    S3-->>Svc: Presigned PUT URL
+    Svc-->>API: {url, key, expiresInSeconds}
+    API-->>Client: Presigned URL 응답
+
+    Client->>S3: PUT 파일 업로드 (Presigned URL)
+    S3-->>Client: 200 + ETag
+
+    Client->>API: POST /uploads/confirm (key, etag)
+    API->>Svc: confirm(target, referenceId, key, etag)
+    Svc->>S3: headObject() ETag/크기 검증
+    S3-->>Svc: 메타데이터
+    Svc-->>API: S3Metadata
+    API-->>Client: 확인 완료
+```
+
+### 3-4. 비동기 알림 워커 흐름
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Svc as NotificationEnqueueService
+    participant DB as PostgreSQL
+    participant Redis as Redis Stream
+    participant Worker as NotificationDispatchWorker
+    participant FCM as Firebase CM
+
+    Svc->>DB: Notification + NotificationTarget 저장
+    Svc->>Redis: XADD notification-stream
+    Redis-->>Worker: XREADGROUP (폴링)
+    Worker->>DB: 타겟 조회 (QUEUED)
+    Worker->>FCM: sendEachForMulticast()
+    alt 성공
+        Worker->>DB: status = SENT
+    else 실패 (재시도 가능)
+        Worker->>DB: retry_count++, status = QUEUED
+        Note over Worker: 지수 백오프 (5s → 10s → 15s, 최대 3회)
+    else UNREGISTERED
+        Worker->>DB: 토큰 삭제
+    end
+    Worker->>Redis: XACK
+```
+
+### 3-5. 매출 엑셀 Export 흐름
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Owner as 사장님
+    participant API as SalesExportController
+    participant Svc as ExportJobService
+    participant DB as PostgreSQL
+    participant Redis as Redis Stream
+    participant Worker as ExportJobDispatchWorker
+    participant S3 as S3/MinIO
+
+    Owner->>API: POST /owner/sales/export
+    API->>Svc: requestExport(storeId, dateRange)
+    Svc->>DB: request_hash 중복 확인
+    alt 기존 작업 존재
+        Svc-->>API: 기존 jobId 반환
+    else 신규
+        Svc->>DB: ExportJob(PENDING) 저장
+        Svc->>Redis: XADD export-stream
+        Svc-->>API: 새 jobId 반환
+    end
+    API-->>Owner: jobId
+
+    Owner->>API: GET /owner/sales/export/{jobId} (폴링)
+
+    Redis-->>Worker: XREADGROUP
+    Worker->>DB: 주문 데이터 조회
+    Worker->>S3: 엑셀 파일 업로드
+    Worker->>DB: status=COMPLETED, file_key 저장
+
+    Owner->>API: GET /owner/sales/export/{jobId}
+    API->>S3: presignGetObject(file_key)
+    API-->>Owner: Presigned Download URL
+```
+
+---
+
+## 4. 역할 기반 접근 제어 (AS-IS)
+
+```mermaid
+flowchart TB
+    subgraph Public["공개 (인증 불필요)"]
+        Login["/api/v1/auth/login"]
+        Signup["/api/v1/auth/signup"]
+        Refresh["/api/v1/auth/token/refresh"]
+        Health["/actuator/health"]
+        Swagger["/swagger-ui/**"]
+    end
+
+    subgraph Consumer["CONSUMER 전용"]
+        Home["/api/v1/home/**"]
+        Orders["/api/v1/orders"]
+        Favorites["/api/v1/favorites"]
+        StoreNsp["/api/v1/stores/{id}/no-show-posts"]
+    end
+
+    subgraph Owner["OWNER 전용"]
+        Stores["/api/v1/stores (CRUD)"]
+        Menus["/api/v1/owner/menus/**"]
+        OwnerNsp["/api/v1/owner/no-show-posts/**"]
+        OwnerOrders["/api/v1/owner/orders/**"]
+        Sales["/api/v1/owner/sales/**"]
+    end
+
+    subgraph Authenticated["인증된 사용자 (역할 무관)"]
+        Push["/api/v1/push/tokens"]
+        Logout["/api/v1/auth/logout"]
+    end
+
+    subgraph Admin["ADMIN (정의됨, 미사용 ⚠️)"]
+        Ghost["SecurityConfig에\n참조 없음"]
+    end
+
+    style Admin fill:#fff3cd,stroke:#ffc107,color:#856404
+    style Ghost fill:#fff3cd,stroke:#ffc107,color:#856404
+```
+
+---
+
+## 5. 보안 분석 요약 (AS-IS)
+
+```mermaid
+mindmap
+  root((보안 현황<br/>Score: 6/10))
+    강점
+      JWE A256GCM 암호화
+      Stateless 세션
+      Redis 토큰 블랙리스트
+      CSRF 비활성화(적절)
+      비관적 잠금(주문 재고)
+    CRITICAL ⛔
+      CORS 와일드카드(*)
+        모든 Origin 허용
+        모든 Method 허용
+        모든 Header 허용
+      Rate Limiting 부재
+        Brute-force 취약
+        DDoS 노출
+    HIGH ⚠️
+      키 로테이션 미구현
+        단일 비밀키
+        갱신 불가
+      Method-level 인가 부재
+        @PreAuthorize 미사용
+        리소스 소유권 미검증
+      토큰 폐기 비원자성
+        Access/Refresh 별도 블랙리스트
+        경쟁 조건 가능
+    MEDIUM 🔶
+      Refresh Token Body 전달
+        CSRF 위험 요소
+      보안 헤더 미설정
+        X-Frame-Options
+        Content-Security-Policy
+      Redis TTL 레이스
+        토큰 만료 vs 블랙리스트 TTL
+      ADMIN 역할 유령
+        정의만 존재
+```
+
+---
+
+## 6. 목표 아키텍처 (TO-BE) — 전체 시스템
+
+```mermaid
+flowchart TB
+    subgraph Clients["🖥️ 클라이언트"]
+        OwnerApp["사장님 앱/웹"]
+        ConsumerApp["소비자 앱/웹"]
+        AdminApp["관리자 대시보드 🆕"]
+    end
+
+    subgraph Edge["엣지 계층 🆕"]
+        CDN["CloudFront / CDN\n(정적 자산 캐시)"]
+        RateLimit["Rate Limiter\n(Bucket4j / Resilience4j)"]
+        CORS["CORS 화이트리스트\n(도메인 명시)"]
+    end
+
+    subgraph SpringBoot["Spring Boot 애플리케이션"]
+        subgraph SecurityEnhanced["보안 계층 (강화)"]
+            JweAuthFilter2["JweAuthFilter"]
+            SecurityConfig2["SecurityConfig\n+ CORS 화이트리스트\n+ Security Headers"]
+            JweTokenService2["JweTokenService\n+ 키 로테이션 🆕"]
+            TokenBlacklist2["TokenBlacklistService\n+ 원자적 폐기 🆕"]
+            MethodSec["@PreAuthorize\n리소스 소유권 검증 🆕"]
+        end
+
+        subgraph Controllers2["컨트롤러 계층"]
+            AllCtrls["기존 컨트롤러 전체\n+ AdminController 🆕\n+ NotificationHistoryController 🆕"]
+        end
+
+        subgraph Services2["서비스 계층"]
+            AllSvcs["기존 서비스 전체\n+ AdminService 🆕\n+ NotificationHistoryService 🆕\n+ PostExpiryScheduler 🆕"]
+        end
+
+        subgraph AsyncWorkers2["비동기 워커 (강화)"]
+            NotiWorker3["NotificationDispatchWorker\n+ DB 상태 업데이트 완성 🆕\n+ DLQ 처리 🆕"]
+            ExportWorker3["ExportJobDispatchWorker"]
+            ExpiryScheduler["PostExpiryScheduler 🆕\n(만료 글 자동 처리)"]
+        end
+
+        subgraph Repositories2["리포지토리 계층"]
+            AllRepos["기존 리포지토리 전체"]
+        end
+
+        subgraph Observability["관측 가능성 🆕"]
+            Metrics["Micrometer / Prometheus"]
+            Logging["Structured Logging\n(JSON)"]
+            Tracing["Distributed Tracing\n(Zipkin/Jaeger)"]
+        end
+    end
+
+    subgraph Infra2["인프라 (강화)"]
+        DB2[("PostgreSQL\n+ PostGIS\n+ Connection Pool\n  최적화")]
+        Redis2[("Redis Sentinel/Cluster\n+ 블랙리스트\n+ Streams\n+ 캐시 🆕")]
+        S3_2[("S3 / MinIO\n+ Lifecycle 정책 🆕\n+ 고아 객체 정리 🆕")]
+        FCM2[("Firebase CM")]
+        Monitoring["Grafana + Prometheus 🆕"]
+    end
+
+    Clients -->|"HTTPS"| Edge
+    Edge -->|"필터링된 요청"| SecurityEnhanced
+    SecurityEnhanced --> Controllers2
+    Controllers2 --> MethodSec
+    MethodSec --> Services2
+    Services2 --> Repositories2
+    Repositories2 --> DB2
+
+    TokenBlacklist2 --> Redis2
+    Services2 --> Redis2
+    Redis2 --> AsyncWorkers2
+    AsyncWorkers2 --> FCM2
+    AsyncWorkers2 --> S3_2
+    Services2 --> S3_2
+
+    SpringBoot --> Observability
+    Observability --> Monitoring
+
+    style Edge fill:#d4edda,stroke:#28a745,color:#155724
+    style AdminApp fill:#d4edda,stroke:#28a745,color:#155724
+    style Observability fill:#d4edda,stroke:#28a745,color:#155724
+    style Monitoring fill:#d4edda,stroke:#28a745,color:#155724
+    style ExpiryScheduler fill:#d4edda,stroke:#28a745,color:#155724
+```
+
+---
+
+## 7. 개선 항목 상세 (TO-BE 로드맵)
+
+### 7-1. 보안 강화 — CORS & Rate Limiting
+
+```mermaid
+flowchart LR
+    subgraph AS_IS["AS-IS ⛔"]
+        CorsNow["CORS: *(와일드카드)\n모든 Origin/Method/Header 허용"]
+        RateNow["Rate Limit: 없음"]
+    end
+
+    subgraph TO_BE["TO-BE ✅"]
+        CorsFix["CORS 화이트리스트\nallowedOrigins:\n  - https://app.dandionna.com\n  - https://owner.dandionna.com\nallowedMethods: GET,POST,PATCH,DELETE\nallowedHeaders: Authorization,Content-Type"]
+        RateFix["Rate Limiting\nBucket4j + Redis 기반\n로그인: 5회/분\nAPI 일반: 100회/분\n엑셀 Export: 3회/시간"]
+    end
+
+    AS_IS -->|"개선"| TO_BE
+    style AS_IS fill:#f8d7da,stroke:#dc3545,color:#721c24
+    style TO_BE fill:#d4edda,stroke:#28a745,color:#155724
+```
+
+### 7-2. 보안 강화 — 키 로테이션 & 토큰 관리
+
+```mermaid
+flowchart TD
+    subgraph AS_IS2["AS-IS"]
+        SingleKey["단일 SecretKey\n(환경변수 BASE64)"]
+        SeparateRevoke["Access/Refresh\n개별 블랙리스트 등록"]
+        NoRefreshCookie["Refresh Token\n= Body 전달"]
+    end
+
+    subgraph TO_BE2["TO-BE"]
+        KeyRotation["키 로테이션\n- kid(Key ID) 헤더 추가\n- 복수 키 동시 유효\n- 정기 교체 스케줄"]
+        AtomicRevoke["원자적 토큰 폐기\n- Lua Script 기반\n- Access+Refresh 동시 블랙리스트"]
+        HttpOnlyCookie["Refresh Token\n= HttpOnly Secure Cookie\n(SameSite=Strict)"]
+    end
+
+    SingleKey -->|"개선"| KeyRotation
+    SeparateRevoke -->|"개선"| AtomicRevoke
+    NoRefreshCookie -->|"개선"| HttpOnlyCookie
+
+    style AS_IS2 fill:#fff3cd,stroke:#ffc107,color:#856404
+    style TO_BE2 fill:#d4edda,stroke:#28a745,color:#155724
+```
+
+### 7-3. 권한 강화 — Method-level Authorization
+
+```mermaid
+flowchart LR
+    subgraph AS_IS3["AS-IS"]
+        UrlOnly["URL 패턴 기반만\n/owner/** → OWNER\n/home/** → CONSUMER\n리소스 소유권 미검증"]
+    end
+
+    subgraph TO_BE3["TO-BE"]
+        MethodAuth["Method-level 인가\n@PreAuthorize 적용"]
+        ResourceOwnership["리소스 소유권 검증\n매장 주인 확인\n주문 소유자 확인"]
+        AdminRole["ADMIN 역할 활성화\n관리자 API 추가\n사용자/매장 관리"]
+    end
+
+    AS_IS3 --> MethodAuth
+    AS_IS3 --> ResourceOwnership
+    AS_IS3 --> AdminRole
+
+    style AS_IS3 fill:#fff3cd,stroke:#ffc107,color:#856404
+    style TO_BE3 fill:#d4edda,stroke:#28a745,color:#155724
+```
+
+### 7-4. 인프라 & 운영 강화
+
+```mermaid
+flowchart TD
+    subgraph Infra_ASIS["AS-IS"]
+        NoScheduler["만료 처리 없음\n(expire_at 지나도 OPEN 유지)"]
+        NoOrphanClean["S3 고아 객체 방치"]
+        NoObserve["모니터링 미구현"]
+        NoDLQ["알림 재시도 실패 시\n별도 처리 없음"]
+        NoSecHeaders["보안 헤더 미설정"]
+    end
+
+    subgraph Infra_TOBE["TO-BE"]
+        Scheduler["PostExpiryScheduler\n@Scheduled(fixedRate)\nexpire_at < now → EXPIRED"]
+        OrphanClean["S3 Lifecycle 정책\n+ 주기적 고아 객체 정리 배치"]
+        Observe["관측 가능성 스택\nMicrometer → Prometheus → Grafana\n+ 구조화 로깅(JSON)\n+ 분산 추적(Zipkin)"]
+        DLQ["Dead Letter Queue\n재시도 소진 → DLQ 이동\n+ 관리자 알림"]
+        SecHeaders["Security Headers\nX-Content-Type-Options: nosniff\nX-Frame-Options: DENY\nStrict-Transport-Security\nContent-Security-Policy"]
+    end
+
+    NoScheduler -->|"구현"| Scheduler
+    NoOrphanClean -->|"구현"| OrphanClean
+    NoObserve -->|"구현"| Observe
+    NoDLQ -->|"구현"| DLQ
+    NoSecHeaders -->|"구현"| SecHeaders
+
+    style Infra_ASIS fill:#f8d7da,stroke:#dc3545,color:#721c24
+    style Infra_TOBE fill:#d4edda,stroke:#28a745,color:#155724
+```
+
+### 7-5. DTO & 검증 통일
+
+```mermaid
+flowchart LR
+    subgraph ASIS_DTO["AS-IS"]
+        Scattered["검증 메시지 분산\n각 DTO별 다른 형식"]
+        NoPageStandard["페이지네이션 응답\n통일되지 않음"]
+    end
+
+    subgraph TOBE_DTO["TO-BE"]
+        Unified["공통 Validation 메시지\nValidationMessages.java\n또는 messages.properties"]
+        PageWrapper["통일된 페이지 응답\nPageResponse<T>\n{ content, page, size,\n  totalElements, totalPages }"]
+    end
+
+    ASIS_DTO --> TOBE_DTO
+    style ASIS_DTO fill:#fff3cd,stroke:#ffc107,color:#856404
+    style TOBE_DTO fill:#d4edda,stroke:#28a745,color:#155724
+```
+
+---
+
+## 8. 데이터베이스 ERD (AS-IS)
+
+```mermaid
+erDiagram
+    users {
+        UUID id PK
+        VARCHAR login_id UK
+        VARCHAR password_hash
+        user_role role
+        TIMESTAMP created_at
+        TIMESTAMP updated_at
+    }
+
+    owner_profiles {
+        BIGINT id PK
+        UUID user_id FK
+        VARCHAR name
+        VARCHAR phone
+    }
+
+    consumer_profiles {
+        BIGINT id PK
+        UUID user_id FK
+        VARCHAR name
+        VARCHAR phone
+    }
+
+    stores {
+        UUID id PK
+        UUID owner_user_id FK
+        VARCHAR store_name
+        VARCHAR address
+        DECIMAL lat
+        DECIMAL lon
+        GEOMETRY geom "GENERATED"
+        VARCHAR phone
+        TIME open_time
+        TIME close_time
+        VARCHAR image_key
+        image_status image_status
+    }
+
+    menus {
+        BIGINT id PK
+        UUID store_id FK
+        VARCHAR name
+        INT price
+        TEXT description
+        VARCHAR image_key
+    }
+
+    no_show_posts {
+        BIGINT id PK
+        UUID store_id FK
+        BIGINT menu_id FK
+        INT qty_total
+        INT qty_remaining
+        INT discount_rate
+        INT original_unit_price
+        INT discounted_unit_price
+        no_show_post_status status
+        TIMESTAMP expire_at
+    }
+
+    no_show_post_history {
+        BIGINT id PK
+        BIGINT post_id FK
+        TEXT snapshot "변경 전 상태"
+    }
+
+    no_show_orders {
+        UUID id PK
+        VARCHAR order_no
+        UUID consumer_user_id FK
+        UUID store_id FK
+        VARCHAR menu_names
+        INT total_price
+        INT paid_amount
+        VARCHAR payment_method
+        payment_status payment_status
+        no_show_order_status status
+        TIMESTAMP visit_time
+        TIMESTAMP paid_at
+    }
+
+    no_show_order_items {
+        BIGINT id PK
+        UUID order_id FK
+        BIGINT no_show_post_id FK
+        BIGINT menu_id FK
+        VARCHAR menu_name
+        INT quantity
+        INT unit_price
+        INT discount_percent
+    }
+
+    favorites {
+        UUID store_id PK
+        UUID consumer_user_id PK
+    }
+
+    push_tokens {
+        BIGINT id PK
+        UUID user_id FK
+        platform platform
+        VARCHAR device_id
+        VARCHAR fcm_token
+        VARCHAR user_agent
+        TIMESTAMP last_seen_at
+    }
+
+    notifications {
+        BIGINT id PK
+        UUID sender_user_id FK
+        VARCHAR category
+        VARCHAR title
+        TEXT body
+        INT priority
+    }
+
+    notification_targets {
+        BIGINT id PK
+        BIGINT notification_id FK
+        UUID target_user_id FK
+        VARCHAR status "QUEUED/SENT/FAILED"
+        INT retry_count
+        TEXT error_log
+    }
+
+    export_jobs {
+        BIGINT id PK
+        UUID store_id FK
+        UUID requested_by FK
+        VARCHAR request_hash
+        export_status status
+        VARCHAR file_key
+        TIMESTAMP expires_at
+    }
+
+    users ||--|| owner_profiles : "has"
+    users ||--|| consumer_profiles : "has"
+    users ||--o{ push_tokens : "owns"
+    users ||--o{ favorites : "favorites"
+    users ||--o{ notifications : "creates"
+    users ||--o{ export_jobs : "requests"
+
+    notifications ||--o{ notification_targets : "targets"
+    users ||--o{ notification_targets : "receives"
+
+    stores ||--|| owner_profiles : "owned_by"
+    stores ||--o{ menus : "has"
+    stores ||--o{ no_show_posts : "has"
+    stores ||--o{ export_jobs : "exports"
+
+    no_show_posts ||--o{ no_show_order_items : "sold_with"
+    no_show_posts ||--o{ no_show_post_history : "history"
+    no_show_orders ||--o{ no_show_order_items : "includes"
+    no_show_orders }o--|| users : "consumer"
+    no_show_orders }o--|| stores : "at_store"
+    favorites }o--|| stores : "watches"
+    menus ||--o{ no_show_posts : "referenced"
+```
+
+---
+
+## 9. 개선 우선순위 매트릭스
+
+```mermaid
+quadrantChart
+    title 개선 항목 우선순위 (영향도 vs 구현 난이도)
+    x-axis "낮은 난이도" --> "높은 난이도"
+    y-axis "낮은 영향도" --> "높은 영향도"
+    quadrant-1 "우선 추진"
+    quadrant-2 "전략적 계획"
+    quadrant-3 "점진적 개선"
+    quadrant-4 "후순위"
+    "CORS 화이트리스트": [0.2, 0.95]
+    "Security Headers": [0.15, 0.7]
+    "Rate Limiting": [0.4, 0.9]
+    "만료 스케줄러": [0.3, 0.6]
+    "@PreAuthorize": [0.45, 0.75]
+    "키 로테이션": [0.7, 0.8]
+    "HttpOnly Cookie": [0.5, 0.65]
+    "원자적 토큰폐기": [0.55, 0.7]
+    "관측 가능성": [0.75, 0.85]
+    "S3 고아 정리": [0.35, 0.35]
+    "DLQ 처리": [0.6, 0.5]
+    "DTO 통일": [0.45, 0.3]
+    "ADMIN API": [0.65, 0.55]
+    "알림 이력 API": [0.5, 0.4]
+```
+
+---
+
+## 10. 구현 단계별 로드맵
+
+```mermaid
+gantt
+    title 개선 로드맵
+    dateFormat YYYY-MM-DD
+    axisFormat %m/%d
+
+    section Phase 1 - 긴급 보안
+    CORS 화이트리스트 설정          :crit, cors, 2026-02-24, 1d
+    Security Headers 추가           :crit, headers, 2026-02-24, 1d
+    Rate Limiting (Bucket4j)        :crit, rate, 2026-02-25, 3d
+
+    section Phase 2 - 인가 강화
+    @PreAuthorize 도입              :auth1, 2026-02-28, 3d
+    리소스 소유권 검증              :auth2, after auth1, 2d
+    ADMIN 역할 활성화               :auth3, after auth2, 2d
+
+    section Phase 3 - 토큰 보안
+    키 로테이션 구현                :key, 2026-03-05, 4d
+    원자적 토큰 폐기 (Lua)         :atomic, after key, 2d
+    Refresh → HttpOnly Cookie       :cookie, after atomic, 2d
+
+    section Phase 4 - 운영 안정화
+    만료 글 자동 스케줄러           :expire, 2026-03-12, 2d
+    S3 고아 객체 정리               :s3clean, after expire, 2d
+    알림 DLQ & 재시도 완성          :dlq, 2026-03-12, 3d
+    알림 이력 조회 API              :notiapi, after dlq, 2d
+
+    section Phase 5 - 관측 & 품질
+    Micrometer + Prometheus 연동    :metric, 2026-03-19, 3d
+    구조화 로깅 (JSON)              :log, 2026-03-19, 2d
+    DTO/Validation 통일             :dto, 2026-03-22, 3d
+    통합 테스트 보강                :test, 2026-03-25, 4d
+```
+
+---
+
+## 부록: 기술 스택 요약
+
+| 구분 | AS-IS | TO-BE (제안) |
+|------|-------|-------------|
+| **Language** | Java 17 | Java 17+ |
+| **Framework** | Spring Boot 3.x | Spring Boot 3.x |
+| **Auth** | JWE (A256GCM) | JWE + 키 로테이션 + HttpOnly Cookie |
+| **DB** | PostgreSQL + PostGIS | + Connection Pool 최적화 |
+| **Cache/Queue** | Redis (Blacklist + Streams) | Redis Sentinel/Cluster + 캐시 계층 |
+| **Storage** | S3/MinIO | + Lifecycle 정책 + 정리 배치 |
+| **Push** | Firebase CM (직접 호출 + 워커) | + DLQ + 재시도 완성 |
+| **보안** | URL 패턴 인가, CORS *, 헤더 없음 | 화이트리스트, @PreAuthorize, 보안 헤더 |
+| **모니터링** | 없음 | Prometheus + Grafana + 구조화 로깅 |
+| **Rate Limit** | 없음 | Bucket4j + Redis |
+| **CI/CD** | GitHub Actions (테스트만) | + 빌드/배포 파이프라인 |

--- a/src/main/java/com/mvp/v1/dandionna/DandionnaApplication.java
+++ b/src/main/java/com/mvp/v1/dandionna/DandionnaApplication.java
@@ -2,8 +2,10 @@ package com.mvp.v1.dandionna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DandionnaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mvp/v1/dandionna/admin/controller/AdminController.java
+++ b/src/main/java/com/mvp/v1/dandionna/admin/controller/AdminController.java
@@ -1,0 +1,47 @@
+package com.mvp.v1.dandionna.admin.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mvp.v1.dandionna.admin.dto.AdminStoreResponse;
+import com.mvp.v1.dandionna.admin.dto.AdminUserResponse;
+import com.mvp.v1.dandionna.admin.service.AdminService;
+import com.mvp.v1.dandionna.common.dto.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminController {
+
+	private final AdminService adminService;
+
+	@Operation(summary = "전체 사용자 목록 조회")
+	@SecurityRequirement(name = "bearerAuth")
+	@GetMapping("/users")
+	public ResponseEntity<ApiResponse<Page<AdminUserResponse>>> listUsers(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size
+	) {
+		return ApiResponse.ok(adminService.listUsers(page, size));
+	}
+
+	@Operation(summary = "전체 매장 목록 조회")
+	@SecurityRequirement(name = "bearerAuth")
+	@GetMapping("/stores")
+	public ResponseEntity<ApiResponse<Page<AdminStoreResponse>>> listStores(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size
+	) {
+		return ApiResponse.ok(adminService.listStores(page, size));
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/admin/dto/AdminStoreResponse.java
+++ b/src/main/java/com/mvp/v1/dandionna/admin/dto/AdminStoreResponse.java
@@ -1,0 +1,25 @@
+package com.mvp.v1.dandionna.admin.dto;
+
+import java.util.UUID;
+
+import com.mvp.v1.dandionna.store.entity.Store;
+
+public record AdminStoreResponse(
+	UUID id,
+	UUID ownerUserId,
+	String name,
+	String category,
+	String phone,
+	String addressRoad
+) {
+	public static AdminStoreResponse from(Store store) {
+		return new AdminStoreResponse(
+			store.getId(),
+			store.getOwnerUserId(),
+			store.getName(),
+			store.getCategory(),
+			store.getPhone(),
+			store.getAddressRoad()
+		);
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/admin/dto/AdminUserResponse.java
+++ b/src/main/java/com/mvp/v1/dandionna/admin/dto/AdminUserResponse.java
@@ -1,0 +1,23 @@
+package com.mvp.v1.dandionna.admin.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.mvp.v1.dandionna.auth.entity.User;
+import com.mvp.v1.dandionna.auth.entity.UserRole;
+
+public record AdminUserResponse(
+	UUID id,
+	String loginId,
+	UserRole role,
+	LocalDateTime createdAt
+) {
+	public static AdminUserResponse from(User user) {
+		return new AdminUserResponse(
+			user.getId(),
+			user.getLoginId(),
+			user.getRole(),
+			user.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/admin/dto/AdminUserResponse.java
+++ b/src/main/java/com/mvp/v1/dandionna/admin/dto/AdminUserResponse.java
@@ -1,6 +1,6 @@
 package com.mvp.v1.dandionna.admin.dto;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import com.mvp.v1.dandionna.auth.entity.User;
@@ -10,7 +10,7 @@ public record AdminUserResponse(
 	UUID id,
 	String loginId,
 	UserRole role,
-	LocalDateTime createdAt
+	OffsetDateTime createdAt
 ) {
 	public static AdminUserResponse from(User user) {
 		return new AdminUserResponse(

--- a/src/main/java/com/mvp/v1/dandionna/admin/service/AdminService.java
+++ b/src/main/java/com/mvp/v1/dandionna/admin/service/AdminService.java
@@ -1,0 +1,38 @@
+package com.mvp.v1.dandionna.admin.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mvp.v1.dandionna.admin.dto.AdminStoreResponse;
+import com.mvp.v1.dandionna.admin.dto.AdminUserResponse;
+import com.mvp.v1.dandionna.auth.repository.UserRepository;
+import com.mvp.v1.dandionna.store.repository.StoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관리자 전용 서비스.
+ * 사용자 및 매장 목록 조회 기능을 제공한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+	private final UserRepository userRepository;
+	private final StoreRepository storeRepository;
+
+	@Transactional(readOnly = true)
+	public Page<AdminUserResponse> listUsers(int page, int size) {
+		return userRepository.findAll(PageRequest.of(page, size, Sort.by("createdAt").descending()))
+			.map(AdminUserResponse::from);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<AdminStoreResponse> listStores(int page, int size) {
+		return storeRepository.findAll(PageRequest.of(page, size, Sort.by("createdAt").descending()))
+			.map(AdminStoreResponse::from);
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/auth/controller/AuthController.java
+++ b/src/main/java/com/mvp/v1/dandionna/auth/controller/AuthController.java
@@ -1,9 +1,10 @@
 package com.mvp.v1.dandionna.auth.controller;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -12,14 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.mvp.v1.dandionna.auth.dto.LoginRequest;
 import com.mvp.v1.dandionna.auth.dto.LoginResponse;
-import com.mvp.v1.dandionna.auth.dto.LogoutRequest;
+import com.mvp.v1.dandionna.auth.dto.RefreshTokenRequest;
 import com.mvp.v1.dandionna.auth.dto.RefreshTokenResponse;
 import com.mvp.v1.dandionna.auth.dto.SignUpRequest;
-import com.mvp.v1.dandionna.auth.dto.RefreshTokenRequest;
 import com.mvp.v1.dandionna.auth.service.AuthService;
 import com.mvp.v1.dandionna.common.dto.ApiResponse;
 import com.mvp.v1.dandionna.common.dto.ErrorCode;
 import com.mvp.v1.dandionna.common.exeption.BusinessException;
+import com.mvp.v1.dandionna.config.Security.JwtProps;
 
 import jakarta.validation.Valid;
 
@@ -36,30 +37,52 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Auth API", description = "사용자 로그인 관리 API")
 @Validated
 public class AuthController {
+
+	private static final String REFRESH_COOKIE_NAME = "refresh_token";
+
 	private final AuthService authService;
+	private final JwtProps jwtProps;
 
 	@Operation(summary = "소비자,사장님 로그인", description = "소비자,사장님 계정으로 로그인합니다.")
 	@PostMapping("/login")
-	public ResponseEntity<ApiResponse<LoginResponse>> consumerLogin(@Valid @RequestBody LoginRequest request) {
-		var response = authService.login(request);
-		return ApiResponse.ok(response);
+	public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+		LoginResponse response = authService.login(request);
+
+		ResponseCookie cookie = buildRefreshCookie(response.refreshToken(),
+			jwtProps.jwt().refreshDays() * 86400L);
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, cookie.toString())
+			.body(ApiResponse.of(response));
 	}
 
-	@Operation(summary = "로그아웃", description = "Access/Refresh 토큰을 블랙리스트에 등록해 무효화합니다.")
+	@Operation(summary = "로그아웃", description = "Access/Refresh 토큰을 원자적으로 블랙리스트에 등록해 무효화합니다.")
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<String>> logout(
 		@RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
-		@Valid @RequestBody LogoutRequest request) {
+		@CookieValue(name = REFRESH_COOKIE_NAME, required = false) String cookieRefreshToken,
+		@RequestBody(required = false) RefreshTokenRequest bodyRequest
+	) {
 		String accessToken = resolveBearer(authorization);
-		authService.logout(accessToken, request);
-		return ApiResponse.ok("로그아웃되었습니다.");
+		String refreshToken = resolveRefreshToken(cookieRefreshToken, bodyRequest);
+		authService.logout(accessToken, refreshToken);
+
+		ResponseCookie clearCookie = buildRefreshCookie("", 0);
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, clearCookie.toString())
+			.body(ApiResponse.of("로그아웃되었습니다."));
 	}
 
 	@Operation(summary = "토큰 재발급", description = "유효한 리프레시 토큰으로 Access 토큰을 재발급합니다.")
 	@PostMapping("/token/refresh")
-	public ResponseEntity<ApiResponse<RefreshTokenResponse>> refresh(@Valid @RequestBody RefreshTokenRequest request) {
-		var response = authService.refresh(request);
-		return ApiResponse.ok(response);
+	public ResponseEntity<ApiResponse<RefreshTokenResponse>> refresh(
+		@CookieValue(name = REFRESH_COOKIE_NAME, required = false) String cookieRefreshToken,
+		@RequestBody(required = false) RefreshTokenRequest bodyRequest
+	) {
+		String refreshToken = resolveRefreshToken(cookieRefreshToken, bodyRequest);
+		String newAccessToken = authService.refresh(refreshToken);
+		return ApiResponse.ok(RefreshTokenResponse.of(newAccessToken));
 	}
 
 	@Operation(summary = "회원가입", description = "로그인 ID, 비밀번호, 역할을 받아 신규 사용자를 생성합니다.")
@@ -67,6 +90,33 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<String>> signup(@Valid @RequestBody SignUpRequest request) {
 		authService.signUp(request);
 		return ApiResponse.created("회원가입이 완료되었습니다.");
+	}
+
+	/**
+	 * HttpOnly, Secure, SameSite=Strict 쿠키를 생성한다.
+	 */
+	private ResponseCookie buildRefreshCookie(String value, long maxAgeSeconds) {
+		return ResponseCookie.from(REFRESH_COOKIE_NAME, value)
+			.httpOnly(true)
+			.secure(true)
+			.sameSite("Strict")
+			.path("/api/v1/auth")
+			.maxAge(maxAgeSeconds)
+			.build();
+	}
+
+	/**
+	 * 쿠키 또는 요청 본문에서 Refresh 토큰을 추출한다.
+	 * 쿠키 우선, 없으면 본문에서 추출한다 (하위 호환).
+	 */
+	private String resolveRefreshToken(String cookieToken, RefreshTokenRequest bodyRequest) {
+		if (cookieToken != null && !cookieToken.isBlank()) {
+			return cookieToken;
+		}
+		if (bodyRequest != null && bodyRequest.refreshToken() != null && !bodyRequest.refreshToken().isBlank()) {
+			return bodyRequest.refreshToken();
+		}
+		throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "리프레시 토큰이 필요합니다.");
 	}
 
 	private String resolveBearer(String authorization) {

--- a/src/main/java/com/mvp/v1/dandionna/auth/service/AuthService.java
+++ b/src/main/java/com/mvp/v1/dandionna/auth/service/AuthService.java
@@ -10,15 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mvp.v1.dandionna.auth.dto.LoginRequest;
 import com.mvp.v1.dandionna.auth.dto.LoginResponse;
-import com.mvp.v1.dandionna.auth.dto.LogoutRequest;
-import com.mvp.v1.dandionna.auth.dto.RefreshTokenRequest;
-import com.mvp.v1.dandionna.auth.dto.RefreshTokenResponse;
 import com.mvp.v1.dandionna.auth.dto.SignUpRequest;
 import com.mvp.v1.dandionna.auth.entity.User;
 import com.mvp.v1.dandionna.auth.repository.UserRepository;
 import com.mvp.v1.dandionna.common.dto.ErrorCode;
 import com.mvp.v1.dandionna.common.exeption.BusinessException;
-import com.mvp.v1.dandionna.config.Security.JwtProps;
 import com.mvp.v1.dandionna.config.Security.JweTokenService;
 
 import io.jsonwebtoken.Claims;
@@ -60,24 +56,26 @@ public class AuthService {
 		userRepository.save(User.create(request.loginId(), encoded, request.role()));
 	}
 
-
+	/**
+	 * Access + Refresh 토큰을 원자적으로 블랙리스트에 등록한다.
+	 * Lua 스크립트를 사용하여 두 토큰이 동시에 블랙리스트되거나, 둘 다 실패한다.
+	 */
 	@Transactional
-	public void logout(String accessToken, LogoutRequest request) {
-		Duration accessTtl = remainingTtl(accessToken);
-		if (!accessTtl.isZero() && !accessTtl.isNegative()) {
-			blacklistService.blacklistAccessToken(accessToken, accessTtl);
-		}
+	public void logout(String accessToken, String refreshToken) {
+		Duration accessTtl = safeRemainingTtl(accessToken);
+		Duration refreshTtl = safeRemainingTtl(refreshToken);
 
-		String refreshToken = request.refreshToken();
-		Duration refreshTtl = remainingTtl(refreshToken);
-		if (!refreshTtl.isZero() && !refreshTtl.isNegative()) {
+		if (accessTtl.isPositive() && refreshTtl.isPositive()) {
+			blacklistService.blacklistBoth(accessToken, accessTtl, refreshToken, refreshTtl);
+		} else if (accessTtl.isPositive()) {
+			blacklistService.blacklistAccessToken(accessToken, accessTtl);
+		} else if (refreshTtl.isPositive()) {
 			blacklistService.blacklistRefreshToken(refreshToken, refreshTtl);
 		}
 	}
 
 	@Transactional(readOnly = true)
-	public RefreshTokenResponse refresh(RefreshTokenRequest request) {
-		String refreshToken = request.refreshToken();
+	public String refresh(String refreshToken) {
 		if (blacklistService.isRefreshTokenBlacklisted(refreshToken)) {
 			throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "블랙리스트 처리된 리프레시 토큰입니다.");
 		}
@@ -87,17 +85,17 @@ public class AuthService {
 		User user = userRepository.findById(UUID.fromString(userId))
 			.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
-		String newAccess = tokenService.issueAccessToken(user.getId().toString(), user.getRole().name());
-		return RefreshTokenResponse.of(newAccess);
+		return tokenService.issueAccessToken(user.getId().toString(), user.getRole().name());
 	}
 
-	private Duration remainingTtl(String token) {
+	private Duration safeRemainingTtl(String token) {
 		try {
 			Claims claims = tokenService.parseClaims(token);
 			Instant exp = claims.getExpiration().toInstant();
-			return Duration.between(Instant.now(), exp);
+			Duration remaining = Duration.between(Instant.now(), exp);
+			return remaining.isNegative() ? Duration.ZERO : remaining;
 		} catch (JwtException ex) {
-			throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "토큰이 유효하지 않습니다.");
+			return Duration.ZERO;
 		}
 	}
 

--- a/src/main/java/com/mvp/v1/dandionna/auth/service/TokenBlacklistService.java
+++ b/src/main/java/com/mvp/v1/dandionna/auth/service/TokenBlacklistService.java
@@ -1,8 +1,10 @@
 package com.mvp.v1.dandionna.auth.service;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * Access/Refresh 토큰 블랙리스트 관리.
  * 토큰 문자열을 키로 저장하고 TTL 을 토큰 남은 수명만큼 지정해 자동 만료시킨다.
+ * 원자적 폐기를 위해 Lua 스크립트로 Access + Refresh를 동시에 블랙리스트한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -17,18 +20,43 @@ public class TokenBlacklistService {
 	private static final String ACCESS_PREFIX = "blacklist:access:";
 	private static final String REFRESH_PREFIX = "blacklist:refresh:";
 
+	/**
+	 * Access + Refresh 토큰을 원자적으로 블랙리스트하는 Lua 스크립트.
+	 * KEYS[1] = access 키, KEYS[2] = refresh 키
+	 * ARGV[1] = access TTL(초), ARGV[2] = refresh TTL(초)
+	 */
+	private static final DefaultRedisScript<Long> ATOMIC_BLACKLIST_SCRIPT =
+		new DefaultRedisScript<>(
+			"redis.call('SET', KEYS[1], '1', 'EX', tonumber(ARGV[1])) " +
+			"redis.call('SET', KEYS[2], '1', 'EX', tonumber(ARGV[2])) " +
+			"return 1",
+			Long.class
+		);
+
 	private final StringRedisTemplate redisTemplate;
+
+	/**
+	 * Access + Refresh 토큰을 원자적으로 블랙리스트에 등록한다.
+	 * 하나만 등록되고 다른 하나가 실패하는 경쟁 조건을 방지한다.
+	 */
+	public void blacklistBoth(String accessToken, Duration accessTtl,
+		String refreshToken, Duration refreshTtl) {
+		String accessKey = ACCESS_PREFIX + accessToken;
+		String refreshKey = REFRESH_PREFIX + refreshToken;
+		redisTemplate.execute(
+			ATOMIC_BLACKLIST_SCRIPT,
+			List.of(accessKey, refreshKey),
+			String.valueOf(accessTtl.toSeconds()),
+			String.valueOf(refreshTtl.toSeconds())
+		);
+	}
 
 	public void blacklistAccessToken(String token, Duration ttl) {
 		redisTemplate.opsForValue().set(ACCESS_PREFIX + token, "1", ttl);
 	}
 
 	public boolean isAccessTokenBlacklisted(String token) {
-		return redisTemplate.hasKey(ACCESS_PREFIX + token);
-	}
-
-	public void removeAccessToken(String token) {
-		redisTemplate.delete(ACCESS_PREFIX + token);
+		return Boolean.TRUE.equals(redisTemplate.hasKey(ACCESS_PREFIX + token));
 	}
 
 	public void blacklistRefreshToken(String token, Duration ttl) {
@@ -36,10 +64,6 @@ public class TokenBlacklistService {
 	}
 
 	public boolean isRefreshTokenBlacklisted(String token) {
-		return redisTemplate.hasKey(REFRESH_PREFIX + token);
-	}
-
-	public void removeRefreshToken(String token) {
-		redisTemplate.delete(REFRESH_PREFIX + token);
+		return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_PREFIX + token));
 	}
 }

--- a/src/main/java/com/mvp/v1/dandionna/common/dto/ErrorCode.java
+++ b/src/main/java/com/mvp/v1/dandionna/common/dto/ErrorCode.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 	PAYMENT_STATE_INVALID(HttpStatus.CONFLICT, "유효하지 않은 결제 상태 전환입니다."),
 	PUSH_TOKEN_EXPIRED(HttpStatus.GONE, "만료된 푸시 토큰입니다."),
 	PUSH_DELIVERY_FAILED(HttpStatus.BAD_GATEWAY, "푸시 전송에 실패했습니다."),
+	RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청이 올바르지 않습니다."),
 	NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),

--- a/src/main/java/com/mvp/v1/dandionna/config/MdcLoggingFilter.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/MdcLoggingFilter.java
@@ -1,0 +1,46 @@
+package com.mvp.v1.dandionna.config;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * 요청 추적을 위한 MDC 필터.
+ * traceId, userId, requestUri를 MDC에 설정하여 구조화 로그에 자동 포함한다.
+ */
+@Component
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			String traceId = request.getHeader("X-Trace-Id");
+			if (traceId == null || traceId.isBlank()) {
+				traceId = UUID.randomUUID().toString().substring(0, 8);
+			}
+			MDC.put("traceId", traceId);
+			MDC.put("requestUri", request.getMethod() + " " + request.getRequestURI());
+
+			Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+			if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal())) {
+				MDC.put("userId", auth.getName());
+			}
+
+			response.setHeader("X-Trace-Id", traceId);
+			filterChain.doFilter(request, response);
+		} finally {
+			MDC.clear();
+		}
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/config/MetricsConfig.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/MetricsConfig.java
@@ -1,0 +1,43 @@
+package com.mvp.v1.dandionna.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * 비즈니스 메트릭 등록.
+ * Prometheus에서 dandionna_* 네임스페이스로 조회 가능.
+ */
+@Configuration
+public class MetricsConfig {
+
+	@Bean
+	public Counter orderCreatedCounter(MeterRegistry registry) {
+		return Counter.builder("dandionna.orders.created")
+			.description("생성된 노쇼 주문 수")
+			.register(registry);
+	}
+
+	@Bean
+	public Counter notificationSentCounter(MeterRegistry registry) {
+		return Counter.builder("dandionna.notifications.sent")
+			.description("전송 성공한 알림 수")
+			.register(registry);
+	}
+
+	@Bean
+	public Counter notificationFailedCounter(MeterRegistry registry) {
+		return Counter.builder("dandionna.notifications.failed")
+			.description("전송 실패한 알림 수 (DLQ 이동)")
+			.register(registry);
+	}
+
+	@Bean
+	public Counter postExpiredCounter(MeterRegistry registry) {
+		return Counter.builder("dandionna.posts.expired")
+			.description("자동 만료 처리된 게시글 수")
+			.register(registry);
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/CorsProperties.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/CorsProperties.java
@@ -1,0 +1,49 @@
+package com.mvp.v1.dandionna.config.Security;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * CORS 허용 목록을 외부 설정에서 주입받는 프로퍼티 클래스.
+ * {@code application.yaml} 또는 환경변수로 설정한다.
+ *
+ * <pre>
+ * app:
+ *   cors:
+ *     allowed-origins:
+ *       - https://app.dandionna.com
+ *       - https://owner.dandionna.com
+ *     allowed-methods:
+ *       - GET
+ *       - POST
+ *       - PATCH
+ *       - DELETE
+ *     allowed-headers:
+ *       - Authorization
+ *       - Content-Type
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(
+	List<String> allowedOrigins,
+	List<String> allowedMethods,
+	List<String> allowedHeaders
+) {
+	private static final List<String> DEFAULT_METHODS =
+		List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS");
+	private static final List<String> DEFAULT_HEADERS =
+		List.of("Authorization", "Content-Type", "X-Requested-With");
+
+	public CorsProperties {
+		if (allowedOrigins == null || allowedOrigins.isEmpty()) {
+			allowedOrigins = List.of("http://localhost:3000", "http://localhost:5173");
+		}
+		if (allowedMethods == null || allowedMethods.isEmpty()) {
+			allowedMethods = DEFAULT_METHODS;
+		}
+		if (allowedHeaders == null || allowedHeaders.isEmpty()) {
+			allowedHeaders = DEFAULT_HEADERS;
+		}
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/JweTokenService.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/JweTokenService.java
@@ -2,6 +2,7 @@ package com.mvp.v1.dandionna.config.Security;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.Map;
 
 import javax.crypto.SecretKey;
 
@@ -14,44 +15,47 @@ import io.jsonwebtoken.security.AeadAlgorithm;
 
 /**
  * JSON Web Encryption(JWE) 토큰 발급·검증을 담당하는 상태 없는 서비스.
- * 암호화 설정은 생성자 주입으로 고정되므로, 이 클래스는 토큰 구조와 만료 시간 계산에만 집중한다.
+ * 키 로테이션을 지원하여 현재 키로 발급하고, 이전 키로도 검증할 수 있다.
  * 요청 처리 흐름은 doc/security-flow.md 를 참고한다.
  *
  * @author rua
  */
 @Service
 public class JweTokenService {
-	private final SecretKey key;
+	private final SecretKey currentKey;
+	private final Map<String, SecretKey> keyMap;
 	private final AeadAlgorithm enc;
 	private final String issuer;
+	private final String kid;
 	private final int accessMinutes;
 	private final int refreshDays;
 
-	public JweTokenService(SecretKey key, AeadAlgorithm enc,
-		JwtProps props) {
-		this.key = key;
+	public JweTokenService(SecretKey jweSecretKey, Map<String, SecretKey> jweKeyMap,
+		AeadAlgorithm enc, JwtProps props) {
+		this.currentKey = jweSecretKey;
+		this.keyMap = jweKeyMap;
 		this.enc = enc;
 		this.issuer = props.jwt().issuer();
+		this.kid = props.jwe().kid();
 		this.accessMinutes = props.jwt().accessMinutes();
 		this.refreshDays = props.jwt().refreshDays();
 	}
 
 	/**
 	 * 컨트롤러 인가에 사용하는 단기 Access 토큰을 발급한다.
-	 *
-	 * @param userId 이후 Authentication#principal 로 저장될 사용자 ID
-	 * @param role   필터에서 "ROLE_{role}" 형태로 래핑할 단순 역할 문자열
+	 * kid 헤더를 포함하여 키 로테이션 시 어떤 키로 암호화했는지 식별한다.
 	 */
 	public String issueAccessToken(String userId, String role) {
 		Instant now = Instant.now();
 		Instant exp = now.plusSeconds(accessMinutes * 60L);
 		return Jwts.builder()
+			.header().add("kid", kid).and()
 			.issuer(issuer)
 			.subject(userId)
 			.claim("role", role)
 			.issuedAt(Date.from(now))
 			.expiration(Date.from(exp))
-			.encryptWith(key, enc)     // JWE(alg=dir, enc=A256GCM) 생성
+			.encryptWith(currentKey, enc)
 			.compact();
 	}
 
@@ -62,24 +66,43 @@ public class JweTokenService {
 		Instant now = Instant.now();
 		Instant exp = now.plusSeconds(refreshDays * 86400L);
 		return Jwts.builder()
+			.header().add("kid", kid).and()
 			.issuer(issuer)
 			.subject(userId)
 			.claim("typ", "refresh")
 			.issuedAt(Date.from(now))
 			.expiration(Date.from(exp))
-			.encryptWith(key, enc)
+			.encryptWith(currentKey, enc)
 			.compact();
 	}
 
 	/**
-	 * 들어온 토큰을 복호화·검증한다. 서명/issuer/만료 검증은 jjwt 가 처리한다.
+	 * 들어온 토큰을 복호화·검증한다.
+	 * 현재 키로 먼저 시도하고, 실패 시 이전 키들로 시도한다 (키 로테이션 지원).
 	 *
 	 * @param compactJwe Authorization 헤더에서 추출한 암호화 토큰
 	 * @return 후속 필터가 사용할 {@link Claims} 페이로드
 	 * @throws JwtException 만료·위조 등으로 토큰이 유효하지 않을 때
 	 */
 	public Claims parseClaims(String compactJwe) throws JwtException {
-		// 복호화 + 표준 클레임 파싱 (exp/iat 등 유효성은 JwtException으로 터짐)
+		// 현재 키로 먼저 시도
+		try {
+			return parseWithKey(compactJwe, currentKey);
+		} catch (JwtException ex) {
+			// 현재 키 실패 시, 다른 키들로 시도
+			for (Map.Entry<String, SecretKey> entry : keyMap.entrySet()) {
+				if (entry.getValue().equals(currentKey)) continue;
+				try {
+					return parseWithKey(compactJwe, entry.getValue());
+				} catch (JwtException ignored) {
+					// 다음 키 시도
+				}
+			}
+			throw ex; // 모든 키 실패
+		}
+	}
+
+	private Claims parseWithKey(String compactJwe, SecretKey key) throws JwtException {
 		return Jwts.parser()
 			.decryptWith(key)
 			.requireIssuer(issuer)

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/JwtProps.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/JwtProps.java
@@ -18,6 +18,13 @@ public record JwtProps(Jwt jwt, Jwe jwe) {
 
 	/**
 	 * JWE 암호화에 필요한 알고리즘/대칭키 설정.
+	 * - secretBase64: 현재 활성 키 (토큰 발급에 사용)
+	 * - previousSecretBase64: 이전 키 (토큰 검증에만 사용, 키 로테이션 시)
+	 * - kid: 현재 키 식별자 (토큰 헤더에 포함)
 	 */
-	public record Jwe(String enc, String secretBase64) {}
+	public record Jwe(String enc, String secretBase64, String previousSecretBase64, String kid) {
+		public Jwe {
+			if (kid == null || kid.isBlank()) kid = "default";
+		}
+	}
 }

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/RateLimitFilter.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/RateLimitFilter.java
@@ -1,0 +1,150 @@
+package com.mvp.v1.dandionna.config.Security;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mvp.v1.dandionna.common.dto.ApiResponse;
+import com.mvp.v1.dandionna.common.dto.ErrorCode;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Redis 기반 슬라이딩 윈도우 Rate Limiting 필터.
+ * 엔드포인트 카테고리별로 다른 제한을 적용한다.
+ *
+ * <ul>
+ *     <li>로그인: IP 기반 5회/분</li>
+ *     <li>엑셀 Export: 사용자 기반 3회/시간</li>
+ *     <li>일반 API: 사용자(또는 IP) 기반 100회/분</li>
+ * </ul>
+ */
+public class RateLimitFilter extends OncePerRequestFilter {
+
+	private static final String RATE_LIMIT_PREFIX = "ratelimit:";
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private final StringRedisTemplate redisTemplate;
+	private final RateLimitProperties properties;
+
+	public RateLimitFilter(StringRedisTemplate redisTemplate, RateLimitProperties properties) {
+		this.redisTemplate = redisTemplate;
+		this.properties = properties;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String path = request.getRequestURI();
+		String method = request.getMethod();
+
+		// 정적 리소스, 헬스체크, Swagger는 제한 없음
+		if (isExcluded(path)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String key;
+		int maxRequests;
+		Duration window;
+
+		if (path.startsWith("/api/v1/auth/login") && "POST".equals(method)) {
+			// 로그인: IP 기반 제한
+			key = RATE_LIMIT_PREFIX + "login:" + getClientIp(request);
+			maxRequests = properties.loginPerMinute();
+			window = Duration.ofMinutes(1);
+		} else if (path.startsWith("/api/v1/owner/sales/export") && "POST".equals(method)) {
+			// 엑셀 Export: 사용자 기반 제한
+			String userId = getCurrentUserId();
+			if (userId == null) {
+				filterChain.doFilter(request, response);
+				return;
+			}
+			key = RATE_LIMIT_PREFIX + "export:" + userId;
+			maxRequests = properties.exportPerHour();
+			window = Duration.ofHours(1);
+		} else {
+			// 일반 API: 사용자 또는 IP 기반 제한
+			String identifier = getCurrentUserId();
+			if (identifier == null) {
+				identifier = "ip:" + getClientIp(request);
+			}
+			key = RATE_LIMIT_PREFIX + "api:" + identifier;
+			maxRequests = properties.apiPerMinute();
+			window = Duration.ofMinutes(1);
+		}
+
+		if (!isAllowed(key, maxRequests, window)) {
+			writeRateLimitResponse(response, maxRequests, window);
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	/**
+	 * Redis INCR + EXPIRE 기반 고정 윈도우 카운터.
+	 * 원자성을 보장하기 위해 increment 후 TTL이 없으면 설정한다.
+	 */
+	private boolean isAllowed(String key, int maxRequests, Duration window) {
+		try {
+			Long count = redisTemplate.opsForValue().increment(key);
+			if (count != null && count == 1) {
+				redisTemplate.expire(key, window);
+			}
+			return count != null && count <= maxRequests;
+		} catch (Exception e) {
+			// Redis 장애 시 요청을 차단하지 않는다 (fail-open)
+			return true;
+		}
+	}
+
+	private void writeRateLimitResponse(HttpServletResponse response, int maxRequests, Duration window)
+		throws IOException {
+		response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+		response.setHeader("Retry-After", String.valueOf(window.toSeconds()));
+		response.setHeader("X-RateLimit-Limit", String.valueOf(maxRequests));
+
+		ApiResponse<Void> body = ApiResponse.ofError(ErrorCode.RATE_LIMIT_EXCEEDED, null);
+		response.getWriter().write(OBJECT_MAPPER.writeValueAsString(body));
+	}
+
+	private String getCurrentUserId() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal())) {
+			return auth.getPrincipal().toString();
+		}
+		return null;
+	}
+
+	private String getClientIp(HttpServletRequest request) {
+		String xff = request.getHeader("X-Forwarded-For");
+		if (xff != null && !xff.isBlank()) {
+			return xff.split(",")[0].trim();
+		}
+		return request.getRemoteAddr();
+	}
+
+	private boolean isExcluded(String path) {
+		return path.startsWith("/actuator")
+			|| path.startsWith("/swagger-ui")
+			|| path.startsWith("/v3/api-docs")
+			|| path.startsWith("/api-docs")
+			|| path.equals("/favicon.ico")
+			|| path.startsWith("/static")
+			|| path.startsWith("/public");
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/RateLimitProperties.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/RateLimitProperties.java
@@ -1,0 +1,27 @@
+package com.mvp.v1.dandionna.config.Security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Rate Limiting 설정을 외부 프로퍼티에서 주입받는 클래스.
+ *
+ * <pre>
+ * app:
+ *   rate-limit:
+ *     login-per-minute: 5
+ *     api-per-minute: 100
+ *     export-per-hour: 3
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "app.rate-limit")
+public record RateLimitProperties(
+	Integer loginPerMinute,
+	Integer apiPerMinute,
+	Integer exportPerHour
+) {
+	public RateLimitProperties {
+		if (loginPerMinute == null || loginPerMinute <= 0) loginPerMinute = 5;
+		if (apiPerMinute == null || apiPerMinute <= 0) apiPerMinute = 100;
+		if (exportPerHour == null || exportPerHour <= 0) exportPerHour = 3;
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityBeans.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityBeans.java
@@ -1,5 +1,8 @@
 package com.mvp.v1.dandionna.config.Security;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -23,14 +26,37 @@ import io.jsonwebtoken.security.AeadAlgorithm;
 @Configuration
 @EnableConfigurationProperties(JwtProps.class)
 public class SecurityBeans {
+
 	/**
-	 * JWE 암복호화에 공용으로 사용하는 대칭 AES 키를 생성한다.
-	 * 실제 키 문자열은 설정/환경 변수에 존재하며 이곳에서만 디코딩된다.
+	 * JWE 암복호화에 사용하는 현재 활성 대칭 AES 키.
+	 * 토큰 발급에 사용된다.
 	 */
 	@Bean
 	public SecretKey jweSecretKey(JwtProps props) {
 		byte[] key = Decoders.BASE64.decode(props.jwe().secretBase64());
-		return new SecretKeySpec(key, "AES"); // A256GCM에 맞는 256-bit 키
+		return new SecretKeySpec(key, "AES");
+	}
+
+	/**
+	 * 키 로테이션을 위한 키 맵.
+	 * kid -> SecretKey 매핑. 현재 키 + 이전 키(있을 경우)를 포함한다.
+	 * 토큰 검증 시 kid 헤더를 보고 적절한 키를 선택한다.
+	 */
+	@Bean
+	public Map<String, SecretKey> jweKeyMap(JwtProps props) {
+		Map<String, SecretKey> keyMap = new LinkedHashMap<>();
+
+		// 현재 활성 키
+		byte[] currentKeyBytes = Decoders.BASE64.decode(props.jwe().secretBase64());
+		keyMap.put(props.jwe().kid(), new SecretKeySpec(currentKeyBytes, "AES"));
+
+		// 이전 키 (로테이션 시 과도기 동안 이전 토큰도 검증 가능)
+		if (props.jwe().previousSecretBase64() != null && !props.jwe().previousSecretBase64().isBlank()) {
+			byte[] prevKeyBytes = Decoders.BASE64.decode(props.jwe().previousSecretBase64());
+			keyMap.put("prev-" + props.jwe().kid(), new SecretKeySpec(prevKeyBytes, "AES"));
+		}
+
+		return keyMap;
 	}
 
 	/**
@@ -38,7 +64,6 @@ public class SecurityBeans {
 	 */
 	@Bean
 	public AeadAlgorithm jweEncAlg(JwtProps props) {
-		// enc는 A128GCM/A192GCM/A256GCM 중 선택. 기본 A256GCM 권장
 		return switch (props.jwe().enc()) {
 			case "A128GCM" -> Jwts.ENC.A128GCM;
 			case "A192GCM" -> Jwts.ENC.A192GCM;

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
 	 *     <li>보안 헤더(X-Content-Type-Options, X-Frame-Options, HSTS 등)를 설정한다.</li>
 	 * </ol>
 	 */
+	@SuppressWarnings("removal")
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http, JweTokenService tokens,
 		TokenBlacklistService blacklistService, StringRedisTemplate redisTemplate) throws Exception {
@@ -62,7 +63,7 @@ public class SecurityConfig {
 					.maxAgeInSeconds(31536000))
 				.referrerPolicy(referrer -> referrer
 					.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
-				.permissionPolicy(permissions -> permissions
+				.permissionsPolicy(permissions -> permissions
 					.policy("camera=(), microphone=(), geolocation=(self)"))
 			)
 			.authorizeHttpRequests(auth -> auth

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.mvp.v1.dandionna.config.Security;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -25,13 +26,15 @@ import com.mvp.v1.dandionna.auth.service.TokenBlacklistService;
  */
 @Configuration
 @EnableMethodSecurity
-@EnableConfigurationProperties(CorsProperties.class)
+@EnableConfigurationProperties({CorsProperties.class, RateLimitProperties.class})
 public class SecurityConfig {
 
 	private final CorsProperties corsProperties;
+	private final RateLimitProperties rateLimitProperties;
 
-	public SecurityConfig(CorsProperties corsProperties) {
+	public SecurityConfig(CorsProperties corsProperties, RateLimitProperties rateLimitProperties) {
 		this.corsProperties = corsProperties;
+		this.rateLimitProperties = rateLimitProperties;
 	}
 
 	/**
@@ -46,7 +49,7 @@ public class SecurityConfig {
 	 */
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http, JweTokenService tokens,
-		TokenBlacklistService blacklistService) throws Exception {
+		TokenBlacklistService blacklistService, StringRedisTemplate redisTemplate) throws Exception {
 		http
 			.cors(Customizer.withDefaults())
 			.csrf(csrf -> csrf.disable())
@@ -85,6 +88,7 @@ public class SecurityConfig {
 				.anyRequest().authenticated()
 			)
 			.addFilterBefore(new JweAuthFilter(tokens, blacklistService), UsernamePasswordAuthenticationFilter.class)
+			.addFilterAfter(new RateLimitFilter(redisTemplate, rateLimitProperties), JweAuthFilter.class)
 			.httpBasic(httpBasic -> httpBasic.disable());
 
 		return http.build();

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
 			)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/auth/**").permitAll()
-				.requestMatchers("/actuator/health",
+				.requestMatchers("/actuator/health", "/actuator/prometheus",
 					"/swagger-ui.html", "/swagger-ui/**",
 					"/v3/api-docs/**", "/api-docs/**").permitAll()
 				.requestMatchers(HttpMethod.GET,

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
 					.maxAgeInSeconds(31536000))
 				.referrerPolicy(referrer -> referrer
 					.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
-				.permissionsPolicy(permissions -> permissions
+				.permissionPolicy(permissions -> permissions
 					.policy("camera=(), microphone=(), geolocation=(self)"))
 			)
 			.authorizeHttpRequests(auth -> auth

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
@@ -1,13 +1,16 @@
 package com.mvp.v1.dandionna.config.Security;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -21,7 +24,16 @@ import com.mvp.v1.dandionna.auth.service.TokenBlacklistService;
  * @author rua
  */
 @Configuration
+@EnableMethodSecurity
+@EnableConfigurationProperties(CorsProperties.class)
 public class SecurityConfig {
+
+	private final CorsProperties corsProperties;
+
+	public SecurityConfig(CorsProperties corsProperties) {
+		this.corsProperties = corsProperties;
+	}
+
 	/**
 	 * 무상태(Stateless) 보안 체인을 등록한다:
 	 * <ol>
@@ -29,6 +41,7 @@ public class SecurityConfig {
 	 *     <li>{@code SessionCreationPolicy.STATELESS} 로 서버 세션 생성을 막는다.</li>
 	 *     <li>헬스체크/인증 엔드포인트는 화이트리스트로 열고 나머지는 보호한다.</li>
 	 *     <li>{@link JweAuthFilter} 를 UsernamePasswordAuthenticationFilter 앞에 추가해 Bearer 토큰을 먼저 처리한다.</li>
+	 *     <li>보안 헤더(X-Content-Type-Options, X-Frame-Options, HSTS 등)를 설정한다.</li>
 	 * </ol>
 	 */
 	@Bean
@@ -38,6 +51,17 @@ public class SecurityConfig {
 			.cors(Customizer.withDefaults())
 			.csrf(csrf -> csrf.disable())
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.headers(headers -> headers
+				.contentTypeOptions(Customizer.withDefaults())
+				.frameOptions(frame -> frame.deny())
+				.httpStrictTransportSecurity(hsts -> hsts
+					.includeSubDomains(true)
+					.maxAgeInSeconds(31536000))
+				.referrerPolicy(referrer -> referrer
+					.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+				.permissionsPolicy(permissions -> permissions
+					.policy("camera=(), microphone=(), geolocation=(self)"))
+			)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/auth/**").permitAll()
 				.requestMatchers("/actuator/health",
@@ -60,7 +84,7 @@ public class SecurityConfig {
 				.requestMatchers("/api/v1/push/**").authenticated()
 				.anyRequest().authenticated()
 			)
-				.addFilterBefore(new JweAuthFilter(tokens, blacklistService), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new JweAuthFilter(tokens, blacklistService), UsernamePasswordAuthenticationFilter.class)
 			.httpBasic(httpBasic -> httpBasic.disable());
 
 		return http.build();
@@ -72,9 +96,11 @@ public class SecurityConfig {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-					.allowedOrigins("*")
-					.allowedMethods("*")
-					.allowedHeaders("*");
+					.allowedOrigins(corsProperties.allowedOrigins().toArray(String[]::new))
+					.allowedMethods(corsProperties.allowedMethods().toArray(String[]::new))
+					.allowedHeaders(corsProperties.allowedHeaders().toArray(String[]::new))
+					.allowCredentials(true)
+					.maxAge(3600);
 			}
 		};
 	}

--- a/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
+++ b/src/main/java/com/mvp/v1/dandionna/config/Security/SecurityConfig.java
@@ -83,6 +83,8 @@ public class SecurityConfig {
 				// 사장님 전용
 				.requestMatchers("/api/v1/owner/**").hasRole("OWNER")
 				.requestMatchers("/api/v1/stores/**").hasRole("OWNER")
+				// 관리자 전용
+				.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
 				// 공통 인증 필요
 				.requestMatchers("/api/v1/push/**").authenticated()
 				.anyRequest().authenticated()

--- a/src/main/java/com/mvp/v1/dandionna/export_job/dto/ExportJobCreateRequest.java
+++ b/src/main/java/com/mvp/v1/dandionna/export_job/dto/ExportJobCreateRequest.java
@@ -1,8 +1,17 @@
 package com.mvp.v1.dandionna.export_job.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record ExportJobCreateRequest(
+	@NotBlank(message = "시작일은 필수입니다.")
+	@Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "시작일 형식은 yyyy-MM-dd 입니다.")
 	String startDate,
+
+	@NotBlank(message = "종료일은 필수입니다.")
+	@Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "종료일 형식은 yyyy-MM-dd 입니다.")
 	String endDate,
+
 	Boolean includeDetail
 ) {
 }

--- a/src/main/java/com/mvp/v1/dandionna/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/mvp/v1/dandionna/favorite/controller/FavoriteController.java
@@ -20,11 +20,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/favorites")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('CONSUMER')")
 public class FavoriteController {
 
 	private final FavoriteService favoriteService;

--- a/src/main/java/com/mvp/v1/dandionna/fcm/controller/PushTokenController.java
+++ b/src/main/java/com/mvp/v1/dandionna/fcm/controller/PushTokenController.java
@@ -3,8 +3,7 @@ package com.mvp.v1.dandionna.fcm.controller;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,8 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mvp.v1.dandionna.common.dto.ApiResponse;
-import com.mvp.v1.dandionna.common.dto.ErrorCode;
-import com.mvp.v1.dandionna.common.exeption.BusinessException;
+import com.mvp.v1.dandionna.common.service.SecurityUtils;
 import com.mvp.v1.dandionna.fcm.dto.PushTokenRegisterRequest;
 import com.mvp.v1.dandionna.fcm.dto.PushTokenRemoveRequest;
 import com.mvp.v1.dandionna.fcm.service.PushTokenService;
@@ -31,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Validated
 @Tag(name = "Push API", description = "푸시 토큰 등록 API")
+@PreAuthorize("isAuthenticated()")
 public class PushTokenController {
 
 	private final PushTokenService pushTokenService;
@@ -39,7 +38,7 @@ public class PushTokenController {
 	@SecurityRequirement(name = "bearerAuth")
 	@PostMapping("/tokens")
 	public ResponseEntity<ApiResponse<String>> register(@Valid @RequestBody PushTokenRegisterRequest request) {
-		UUID userId = currentUserId();
+		UUID userId = SecurityUtils.getCurrentUserId();
 		pushTokenService.register(userId, request);
 		return ApiResponse.created("푸시 토큰이 등록되었습니다.");
 	}
@@ -48,20 +47,8 @@ public class PushTokenController {
 	@SecurityRequirement(name = "bearerAuth")
 	@DeleteMapping("/tokens")
 	public ResponseEntity<ApiResponse<Void>> remove(@Valid @RequestBody PushTokenRemoveRequest request) {
-		UUID userId = currentUserId();
+		UUID userId = SecurityUtils.getCurrentUserId();
 		pushTokenService.unregister(userId, request);
 		return ApiResponse.ok(null);
-	}
-
-	private UUID currentUserId() {
-		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		if (authentication == null || authentication.getPrincipal() == null) {
-			throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "인증 정보가 없습니다.");
-		}
-		try {
-			return UUID.fromString(authentication.getPrincipal().toString());
-		} catch (IllegalArgumentException ex) {
-			throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN, "잘못된 사용자 식별자입니다.");
-		}
 	}
 }

--- a/src/main/java/com/mvp/v1/dandionna/home/controller/HomeController.java
+++ b/src/main/java/com/mvp/v1/dandionna/home/controller/HomeController.java
@@ -22,11 +22,13 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/home")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('CONSUMER')")
 public class HomeController {
 
 	private final HomeService homeService;

--- a/src/main/java/com/mvp/v1/dandionna/menu/controller/MenuController.java
+++ b/src/main/java/com/mvp/v1/dandionna/menu/controller/MenuController.java
@@ -26,11 +26,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/owner/menus")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('OWNER')")
 public class MenuController {
 
 	private final MenuService menuService;

--- a/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/NoShowOrderConsumerController.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/NoShowOrderConsumerController.java
@@ -19,11 +19,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/orders")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('CONSUMER')")
 public class NoShowOrderConsumerController {
 
 	private final NoShowOrderConsumerService consumerService;

--- a/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/NoShowOrderController.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/NoShowOrderController.java
@@ -25,11 +25,13 @@ import com.mvp.v1.dandionna.noshow_order.service.NoShowOrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/owner/orders")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('OWNER')")
 public class NoShowOrderController {
 
 	private final NoShowOrderService noShowOrderService;

--- a/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/OwnerSalesController.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/OwnerSalesController.java
@@ -17,11 +17,13 @@ import com.mvp.v1.dandionna.noshow_order.service.OwnerSalesService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/owner/sales")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('OWNER')")
 public class OwnerSalesController {
 
 	private final OwnerSalesService ownerSalesService;

--- a/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/OwnerSalesExportController.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/OwnerSalesExportController.java
@@ -21,11 +21,13 @@ import com.mvp.v1.dandionna.export_job.service.ExportJobService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/owner/sales/export")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('OWNER')")
 public class OwnerSalesExportController {
 
 	private final ExportJobService exportJobService;

--- a/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/OwnerSalesExportController.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_order/controller/OwnerSalesExportController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
+
 import com.mvp.v1.dandionna.common.dto.ApiResponse;
 import com.mvp.v1.dandionna.common.service.SecurityUtils;
 import com.mvp.v1.dandionna.export_job.dto.ExportJobCreateRequest;
@@ -36,7 +38,7 @@ public class OwnerSalesExportController {
 	@SecurityRequirement(name = "bearerAuth")
 	@PostMapping
 	public ResponseEntity<ApiResponse<ExportJobCreateResponse>> create(
-		@RequestBody ExportJobCreateRequest request
+		@Valid @RequestBody ExportJobCreateRequest request
 	) {
 		UUID ownerId = SecurityUtils.getCurrentUserId();
 		ExportJobCreateResponse response = exportJobService.requestOwnerSalesExport(ownerId, request);

--- a/src/main/java/com/mvp/v1/dandionna/noshow_order/dto/NoShowOrderCompleteRequest.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_order/dto/NoShowOrderCompleteRequest.java
@@ -1,5 +1,8 @@
 package com.mvp.v1.dandionna.noshow_order.dto;
 
+import jakarta.validation.constraints.Size;
+
 public record NoShowOrderCompleteRequest(
+	@Size(max = 500, message = "메모는 500자 이내로 작성해주세요.")
 	String storeMemo
 ) {}

--- a/src/main/java/com/mvp/v1/dandionna/noshow_order/service/NoShowOrderConsumerService.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_order/service/NoShowOrderConsumerService.java
@@ -40,6 +40,7 @@ import com.mvp.v1.dandionna.notification.service.NotificationEnqueueService;
 import com.mvp.v1.dandionna.store.entity.Store;
 import com.mvp.v1.dandionna.store.repository.StoreRepository;
 
+import io.micrometer.core.instrument.Counter;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -61,6 +62,7 @@ public class NoShowOrderConsumerService {
 	private final ConsumerProfileRepository consumerProfileRepository;
 	private final FcmNotificationService fcmNotificationService;
 	private final NotificationEnqueueService notificationEnqueueService;
+	private final Counter orderCreatedCounter;
 
 	@Transactional
 	public NoShowOrderCreateResponse createOrder(UUID consumerId, NoShowOrderCreateRequest request) {
@@ -153,6 +155,7 @@ public class NoShowOrderConsumerService {
 		}
 		ConsumerProfile consumerProfile = consumerProfileRepository.findById(consumerId).orElse(null);
 		notifyOwner(store, saved, consumerProfile);
+		orderCreatedCounter.increment();
 
 		return new NoShowOrderCreateResponse(
 			saved.getId(),

--- a/src/main/java/com/mvp/v1/dandionna/noshow_post/controller/NoShowPostController.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_post/controller/NoShowPostController.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 /**
  * @author rua
@@ -34,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("api/v1/owner/no-show-posts")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('OWNER')")
 public class NoShowPostController {
 
 	private final NoShowPostService noShowPostService;

--- a/src/main/java/com/mvp/v1/dandionna/noshow_post/entity/NoShowPost.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_post/entity/NoShowPost.java
@@ -129,6 +129,10 @@ public class NoShowPost extends BaseEntity {
 		this.status = NoShowPostStatus.open;
 	}
 
+	public void markExpired() {
+		this.status = NoShowPostStatus.expired;
+	}
+
 	public void consumeQuantity(int amount) {
 		if (amount <= 0) {
 			throw new IllegalArgumentException("차감 수량은 0보다 커야 합니다.");

--- a/src/main/java/com/mvp/v1/dandionna/noshow_post/repository/NoShowPostRepository.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_post/repository/NoShowPostRepository.java
@@ -41,4 +41,13 @@ public interface NoShowPostRepository extends JpaRepository<NoShowPost, Long> {
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select p from NoShowPost p where p.id in :ids and p.deletedAt is null")
 	List<NoShowPost> findAllByIdInForUpdate(@Param("ids") Collection<Long> ids);
+
+	/**
+	 * 만료 시간이 지났지만 아직 open 상태인 게시글을 조회한다 (스케줄러용).
+	 */
+	@Query("select p from NoShowPost p where p.status = :status and p.expireAt < :now and p.deletedAt is null")
+	List<NoShowPost> findExpiredPosts(
+		@Param("status") NoShowPostStatus status,
+		@Param("now") OffsetDateTime now
+	);
 }

--- a/src/main/java/com/mvp/v1/dandionna/noshow_post/service/PostExpiryScheduler.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_post/service/PostExpiryScheduler.java
@@ -1,0 +1,44 @@
+package com.mvp.v1.dandionna.noshow_post.service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mvp.v1.dandionna.noshow_post.entity.NoShowPost;
+import com.mvp.v1.dandionna.noshow_post.entity.NoShowPostStatus;
+import com.mvp.v1.dandionna.noshow_post.repository.NoShowPostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 만료 시간이 지난 노쇼 게시글을 자동으로 EXPIRED 상태로 변경하는 스케줄러.
+ * 매 1분마다 실행되어 expire_at < now 이면서 아직 open 상태인 글을 처리한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class PostExpiryScheduler {
+
+	private static final Logger log = LoggerFactory.getLogger(PostExpiryScheduler.class);
+
+	private final NoShowPostRepository noShowPostRepository;
+
+	@Scheduled(fixedRate = 60_000) // 1분마다 실행
+	@Transactional
+	public void expirePosts() {
+		List<NoShowPost> expired = noShowPostRepository.findExpiredPosts(
+			NoShowPostStatus.open, OffsetDateTime.now());
+
+		if (expired.isEmpty()) return;
+
+		for (NoShowPost post : expired) {
+			post.markExpired();
+		}
+
+		log.info("만료 처리된 노쇼 게시글: {}건", expired.size());
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/noshow_post/service/PostExpiryScheduler.java
+++ b/src/main/java/com/mvp/v1/dandionna/noshow_post/service/PostExpiryScheduler.java
@@ -13,6 +13,7 @@ import com.mvp.v1.dandionna.noshow_post.entity.NoShowPost;
 import com.mvp.v1.dandionna.noshow_post.entity.NoShowPostStatus;
 import com.mvp.v1.dandionna.noshow_post.repository.NoShowPostRepository;
 
+import io.micrometer.core.instrument.Counter;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -26,6 +27,7 @@ public class PostExpiryScheduler {
 	private static final Logger log = LoggerFactory.getLogger(PostExpiryScheduler.class);
 
 	private final NoShowPostRepository noShowPostRepository;
+	private final Counter postExpiredCounter;
 
 	@Scheduled(fixedRate = 60_000) // 1분마다 실행
 	@Transactional
@@ -38,7 +40,7 @@ public class PostExpiryScheduler {
 		for (NoShowPost post : expired) {
 			post.markExpired();
 		}
-
+		postExpiredCounter.increment(expired.size());
 		log.info("만료 처리된 노쇼 게시글: {}건", expired.size());
 	}
 }

--- a/src/main/java/com/mvp/v1/dandionna/notification/controller/NotificationController.java
+++ b/src/main/java/com/mvp/v1/dandionna/notification/controller/NotificationController.java
@@ -1,0 +1,41 @@
+package com.mvp.v1.dandionna.notification.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mvp.v1.dandionna.common.dto.ApiResponse;
+import com.mvp.v1.dandionna.common.service.SecurityUtils;
+import com.mvp.v1.dandionna.notification.dto.NotificationHistoryResponse;
+import com.mvp.v1.dandionna.notification.service.NotificationHistoryService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
+public class NotificationController {
+
+	private final NotificationHistoryService notificationHistoryService;
+
+	@Operation(summary = "알림 이력 조회", description = "로그인 사용자의 알림 이력을 페이지네이션하여 조회합니다.")
+	@SecurityRequirement(name = "bearerAuth")
+	@GetMapping
+	public ResponseEntity<ApiResponse<Page<NotificationHistoryResponse>>> getHistory(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size
+	) {
+		UUID userId = SecurityUtils.getCurrentUserId();
+		Page<NotificationHistoryResponse> history = notificationHistoryService.getHistory(userId, page, size);
+		return ApiResponse.ok(history);
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/notification/dto/NotificationHistoryResponse.java
+++ b/src/main/java/com/mvp/v1/dandionna/notification/dto/NotificationHistoryResponse.java
@@ -1,0 +1,14 @@
+package com.mvp.v1.dandionna.notification.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record NotificationHistoryResponse(
+	UUID notificationId,
+	String title,
+	String body,
+	String category,
+	String status,
+	OffsetDateTime createdAt
+) {
+}

--- a/src/main/java/com/mvp/v1/dandionna/notification/entity/Notification.java
+++ b/src/main/java/com/mvp/v1/dandionna/notification/entity/Notification.java
@@ -29,6 +29,9 @@ public class Notification {
 	@JdbcTypeCode(SqlTypes.JSON)
 	private Object data;
 
+	private String category;
+	private String priority;
+
 	@Column(name = "created_at")
 	private OffsetDateTime createdAt;
 }

--- a/src/main/java/com/mvp/v1/dandionna/notification/entity/NotificationTarget.java
+++ b/src/main/java/com/mvp/v1/dandionna/notification/entity/NotificationTarget.java
@@ -19,6 +19,9 @@ public class NotificationTarget {
 	@Id
 	private Long id;
 
+	@Column(name = "notification_id", nullable = false)
+	private UUID notificationId;
+
 	@Column(name = "user_id", nullable = false)
 	private UUID userId;
 
@@ -42,6 +45,9 @@ public class NotificationTarget {
 
 	@Column(name = "message_id")
 	private String messageId;
+
+	@Column(name = "created_at")
+	private OffsetDateTime createdAt;
 
 	@Column(name = "updated_at")
 	private OffsetDateTime updatedAt;

--- a/src/main/java/com/mvp/v1/dandionna/notification/repository/NotificationTargetRepository.java
+++ b/src/main/java/com/mvp/v1/dandionna/notification/repository/NotificationTargetRepository.java
@@ -1,15 +1,30 @@
 package com.mvp.v1.dandionna.notification.repository;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.mvp.v1.dandionna.notification.dto.NotificationHistoryResponse;
 import com.mvp.v1.dandionna.notification.entity.NotificationTarget;
 
 public interface NotificationTargetRepository extends JpaRepository<NotificationTarget, Long> {
+
+	@Query("""
+		select new com.mvp.v1.dandionna.notification.dto.NotificationHistoryResponse(
+			n.id, n.title, n.body, n.category, nt.status, nt.createdAt
+		)
+		from NotificationTarget nt
+		join Notification n on n.id = nt.notificationId
+		where nt.userId = :userId
+		order by nt.createdAt desc
+		""")
+	Page<NotificationHistoryResponse> findHistoryByUserId(@Param("userId") UUID userId, Pageable pageable);
 
 	@Modifying
 	@Query("""

--- a/src/main/java/com/mvp/v1/dandionna/notification/service/NotificationHistoryService.java
+++ b/src/main/java/com/mvp/v1/dandionna/notification/service/NotificationHistoryService.java
@@ -1,0 +1,25 @@
+package com.mvp.v1.dandionna.notification.service;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mvp.v1.dandionna.notification.dto.NotificationHistoryResponse;
+import com.mvp.v1.dandionna.notification.repository.NotificationTargetRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationHistoryService {
+
+	private final NotificationTargetRepository notificationTargetRepository;
+
+	@Transactional(readOnly = true)
+	public Page<NotificationHistoryResponse> getHistory(UUID userId, int page, int size) {
+		return notificationTargetRepository.findHistoryByUserId(userId, PageRequest.of(page, size));
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/notification/worker/NotificationDispatchWorker.java
+++ b/src/main/java/com/mvp/v1/dandionna/notification/worker/NotificationDispatchWorker.java
@@ -20,17 +20,20 @@ import com.mvp.v1.dandionna.notification.entity.NotificationTarget;
 import com.mvp.v1.dandionna.notification.repository.NotificationTargetRepository;
 
 /**
- * Redis Stream 기반 알림 전송 워커 스켈레톤.
+ * Redis Stream 기반 알림 전송 워커.
  * - Stream key: notification:queue
- * - Consumer group/offset 관리, FCM 전송/DB 상태 업데이트는 추후 확장
+ * - 최대 3회 재시도 후 DLQ(notification:dlq)로 이동
+ * - Consumer group 기반 처리, FCM 전송 및 DB 상태 업데이트
  */
 @Component
 public class NotificationDispatchWorker {
 
 	private static final Logger log = LoggerFactory.getLogger(NotificationDispatchWorker.class);
 	private static final String STREAM_KEY = "notification:queue";
+	private static final String DLQ_STREAM_KEY = "notification:dlq";
 	private static final String GROUP = "notification-workers";
 	private static final String CONSUMER = "worker-1";
+	private static final int MAX_ATTEMPTS = 3;
 
 	private final StringRedisTemplate redisTemplate;
 	private final FcmNotificationService fcmNotificationService;
@@ -93,20 +96,26 @@ public class NotificationDispatchWorker {
 					continue;
 				}
 				int nextAttempt = attemptFromDb + 1;
-				int backoffSec = backoffSeconds(nextAttempt);
-				String status = nextAttempt > 3 ? "FAILED" : "QUEUED";
-				OffsetDateTime nextRetryAt = status.equals("FAILED") ? null : OffsetDateTime.now().plusSeconds(backoffSec);
-				if (target != null) {
-					notificationTargetRepository.markFailure(
-						payload.targetId(),
-						status,
-						nextAttempt,
-						"FCM_FAILED",
-						"FCM send failed",
-						nextRetryAt
-					);
-				}
-				if ("QUEUED".equals(status)) {
+				if (nextAttempt > MAX_ATTEMPTS) {
+					// 최대 재시도 초과 → DLQ로 이동
+					moveToDlq(payload, nextAttempt, "FCM_FAILED", "FCM send failed after " + MAX_ATTEMPTS + " attempts");
+					if (target != null) {
+						notificationTargetRepository.markFailure(
+							payload.targetId(), "FAILED", nextAttempt,
+							"FCM_FAILED", "FCM send failed after " + MAX_ATTEMPTS + " attempts", null
+						);
+					}
+					log.warn("알림 DLQ 이동: targetId={}, userId={}, attempt={}", payload.targetId(), payload.userId(), nextAttempt);
+				} else {
+					// 재시도 예약
+					int backoffSec = backoffSeconds(nextAttempt);
+					OffsetDateTime nextRetryAt = OffsetDateTime.now().plusSeconds(backoffSec);
+					if (target != null) {
+						notificationTargetRepository.markFailure(
+							payload.targetId(), "QUEUED", nextAttempt,
+							"FCM_FAILED", "FCM send failed", nextRetryAt
+						);
+					}
 					requeue(payload, nextAttempt, nextRetryAt);
 				}
 			} catch (Exception e) {
@@ -123,6 +132,65 @@ public class NotificationDispatchWorker {
 			case 2 -> 10;
 			default -> 15;
 		};
+	}
+
+	/**
+	 * DLQ 메시지를 메인 큐로 재투입한다 (attempt 초기화).
+	 * @return 재투입된 메시지 수
+	 */
+	public int replayDlq(int maxCount) {
+		List<MapRecord<String, Object, Object>> records = redisTemplate.opsForStream().read(
+			StreamOffset.create(DLQ_STREAM_KEY, ReadOffset.from("0-0"))
+		);
+		if (records == null || records.isEmpty()) {
+			return 0;
+		}
+		int replayed = 0;
+		for (MapRecord<String, Object, Object> record : records) {
+			if (replayed >= maxCount) {
+				break;
+			}
+			DispatchPayload payload = DispatchPayload.from(record.getValue());
+			if (payload != null) {
+				requeue(payload, 0, null);
+				if (payload.targetId() != null) {
+					notificationTargetRepository.markFailure(
+						payload.targetId(), "QUEUED", 0,
+						null, "DLQ 재투입", OffsetDateTime.now()
+					);
+				}
+			}
+			redisTemplate.opsForStream().delete(DLQ_STREAM_KEY, record.getId());
+			replayed++;
+		}
+		log.info("DLQ 재처리 완료: {}건", replayed);
+		return replayed;
+	}
+
+	/**
+	 * DLQ 메시지 수를 반환한다.
+	 */
+	public long getDlqSize() {
+		Long size = redisTemplate.opsForStream().size(DLQ_STREAM_KEY);
+		return size != null ? size : 0;
+	}
+
+	private void moveToDlq(DispatchPayload payload, int attempt, String errorCode, String errorMessage) {
+		Map<String, String> map = new java.util.HashMap<>();
+		if (payload.targetId() != null) {
+			map.put("targetId", payload.targetId().toString());
+		}
+		map.put("userId", payload.userId().toString());
+		map.put("title", payload.title());
+		map.put("body", payload.body());
+		map.put("attempt", String.valueOf(attempt));
+		map.put("errorCode", errorCode);
+		map.put("errorMessage", errorMessage);
+		map.put("failedAt", OffsetDateTime.now().toString());
+		if (payload.data() != null) {
+			payload.data().forEach((k, v) -> map.put("data." + k, v));
+		}
+		redisTemplate.opsForStream().add(DLQ_STREAM_KEY, map);
 	}
 
 	private void requeue(DispatchPayload payload, int attempt, OffsetDateTime nextRetryAt) {

--- a/src/main/java/com/mvp/v1/dandionna/notification/worker/NotificationDispatchWorker.java
+++ b/src/main/java/com/mvp/v1/dandionna/notification/worker/NotificationDispatchWorker.java
@@ -19,6 +19,8 @@ import com.mvp.v1.dandionna.fcm.service.FcmNotificationService;
 import com.mvp.v1.dandionna.notification.entity.NotificationTarget;
 import com.mvp.v1.dandionna.notification.repository.NotificationTargetRepository;
 
+import io.micrometer.core.instrument.Counter;
+
 /**
  * Redis Stream 기반 알림 전송 워커.
  * - Stream key: notification:queue
@@ -38,13 +40,19 @@ public class NotificationDispatchWorker {
 	private final StringRedisTemplate redisTemplate;
 	private final FcmNotificationService fcmNotificationService;
 	private final NotificationTargetRepository notificationTargetRepository;
+	private final Counter notificationSentCounter;
+	private final Counter notificationFailedCounter;
 
 	public NotificationDispatchWorker(StringRedisTemplate redisTemplate,
 		FcmNotificationService fcmNotificationService,
-		NotificationTargetRepository notificationTargetRepository) {
+		NotificationTargetRepository notificationTargetRepository,
+		Counter notificationSentCounter,
+		Counter notificationFailedCounter) {
 		this.redisTemplate = redisTemplate;
 		this.fcmNotificationService = fcmNotificationService;
 		this.notificationTargetRepository = notificationTargetRepository;
+		this.notificationSentCounter = notificationSentCounter;
+		this.notificationFailedCounter = notificationFailedCounter;
 		ensureGroup();
 	}
 
@@ -93,6 +101,7 @@ public class NotificationDispatchWorker {
 					if (target != null) {
 						notificationTargetRepository.markSuccess(payload.targetId(), null);
 					}
+					notificationSentCounter.increment();
 					continue;
 				}
 				int nextAttempt = attemptFromDb + 1;
@@ -105,6 +114,7 @@ public class NotificationDispatchWorker {
 							"FCM_FAILED", "FCM send failed after " + MAX_ATTEMPTS + " attempts", null
 						);
 					}
+					notificationFailedCounter.increment();
 					log.warn("알림 DLQ 이동: targetId={}, userId={}, attempt={}", payload.targetId(), payload.userId(), nextAttempt);
 				} else {
 					// 재시도 예약

--- a/src/main/java/com/mvp/v1/dandionna/s3/controller/MenuUploadController.java
+++ b/src/main/java/com/mvp/v1/dandionna/s3/controller/MenuUploadController.java
@@ -29,11 +29,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/menus/{menuId}/uploads")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('OWNER')")
 public class MenuUploadController {
 
 	private final UploadService uploadService;

--- a/src/main/java/com/mvp/v1/dandionna/s3/controller/StoreUploadController.java
+++ b/src/main/java/com/mvp/v1/dandionna/s3/controller/StoreUploadController.java
@@ -28,11 +28,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/stores/uploads")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('OWNER')")
 public class StoreUploadController {
 
 	private final UploadService uploadService;

--- a/src/main/java/com/mvp/v1/dandionna/s3/service/OrphanObjectCleanupScheduler.java
+++ b/src/main/java/com/mvp/v1/dandionna/s3/service/OrphanObjectCleanupScheduler.java
@@ -1,0 +1,111 @@
+package com.mvp.v1.dandionna.s3.service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.mvp.v1.dandionna.menu.repository.MenuRepository;
+import com.mvp.v1.dandionna.store.repository.StoreRepository;
+
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+/**
+ * S3/MinIO에서 DB에 참조되지 않는 고아 객체를 정리하는 스케줄러.
+ * 매일 새벽 3시에 실행되며, 24시간 이상 지난 미참조 객체만 삭제한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class OrphanObjectCleanupScheduler {
+
+	private static final Logger log = LoggerFactory.getLogger(OrphanObjectCleanupScheduler.class);
+
+	private final S3Client s3Client;
+	private final StoreRepository storeRepository;
+	private final MenuRepository menuRepository;
+
+	@Value("${app.s3.bucket}")
+	private String bucket;
+
+	@Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+	public void cleanupOrphanObjects() {
+		Set<String> referencedKeys = collectReferencedKeys();
+		List<String> orphanKeys = new ArrayList<>();
+
+		Instant cutoff = Instant.now().minus(24, ChronoUnit.HOURS);
+
+		// stores/ 폴더
+		orphanKeys.addAll(findOrphansInPrefix("stores/", referencedKeys, cutoff));
+		// menus/ 폴더
+		orphanKeys.addAll(findOrphansInPrefix("menus/", referencedKeys, cutoff));
+
+		for (String key : orphanKeys) {
+			try {
+				s3Client.deleteObject(DeleteObjectRequest.builder()
+					.bucket(bucket).key(key).build());
+			} catch (Exception e) {
+				log.warn("고아 객체 삭제 실패: {}", key, e);
+			}
+		}
+
+		if (!orphanKeys.isEmpty()) {
+			log.info("S3 고아 객체 정리 완료: {}건 삭제", orphanKeys.size());
+		}
+	}
+
+	private Set<String> collectReferencedKeys() {
+		Set<String> keys = storeRepository.findAll().stream()
+			.filter(s -> s.getImageKey() != null)
+			.map(s -> s.getImageKey())
+			.collect(Collectors.toSet());
+
+		menuRepository.findAll().stream()
+			.filter(m -> m.getImageKey() != null)
+			.map(m -> m.getImageKey())
+			.forEach(keys::add);
+
+		return keys;
+	}
+
+	private List<String> findOrphansInPrefix(String prefix, Set<String> referencedKeys, Instant cutoff) {
+		List<String> orphans = new ArrayList<>();
+		String continuationToken = null;
+
+		do {
+			ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
+				.bucket(bucket)
+				.prefix(prefix)
+				.maxKeys(1000);
+
+			if (continuationToken != null) {
+				requestBuilder.continuationToken(continuationToken);
+			}
+
+			ListObjectsV2Response response = s3Client.listObjectsV2(requestBuilder.build());
+
+			for (S3Object obj : response.contents()) {
+				if (!referencedKeys.contains(obj.key())
+					&& obj.lastModified().isBefore(cutoff)) {
+					orphans.add(obj.key());
+				}
+			}
+
+			continuationToken = response.isTruncated() ? response.nextContinuationToken() : null;
+		} while (continuationToken != null);
+
+		return orphans;
+	}
+}

--- a/src/main/java/com/mvp/v1/dandionna/store/controller/StoreConsumerController.java
+++ b/src/main/java/com/mvp/v1/dandionna/store/controller/StoreConsumerController.java
@@ -17,11 +17,13 @@ import com.mvp.v1.dandionna.store.service.StoreConsumerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/stores")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('CONSUMER')")
 public class StoreConsumerController {
 
 	private final StoreConsumerService storeConsumerService;

--- a/src/main/java/com/mvp/v1/dandionna/store/controller/StoreController.java
+++ b/src/main/java/com/mvp/v1/dandionna/store/controller/StoreController.java
@@ -24,11 +24,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1/stores")
 @Validated
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('OWNER')")
 public class StoreController {
 
     private final StoreService storeService;

--- a/src/main/java/com/mvp/v1/dandionna/store/dto/StoreUpdateRequest.java
+++ b/src/main/java/com/mvp/v1/dandionna/store/dto/StoreUpdateRequest.java
@@ -3,15 +3,25 @@ package com.mvp.v1.dandionna.store.dto;
 import java.math.BigDecimal;
 import java.time.LocalTime;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Size;
+
 public record StoreUpdateRequest(
+	@Size(max = 100, message = "매장명은 100자 이내로 작성해주세요.")
 	String name,
 	String category,
-    String phone,
+	String phone,
 	String addressRoad,
+	@DecimalMin(value = "-90.0", message = "위도는 -90 이상이어야 합니다.")
+	@DecimalMax(value = "90.0", message = "위도는 90 이하여야 합니다.")
 	BigDecimal lat,
+	@DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 합니다.")
+	@DecimalMax(value = "180.0", message = "경도는 180 이하여야 합니다.")
 	BigDecimal lon,
 	LocalTime openTime,
 	LocalTime closeTime,
+	@Size(max = 1000, message = "설명은 1000자 이내로 작성해주세요.")
 	String description,
 	String imageKey,
 	String imageMime,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus,info
+  endpoint:
+    health:
+      show-details: when-authorized
+  metrics:
+    tags:
+      application: dandionna

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProfile name="!prod">
+        <!-- 로컬 개발: 사람이 읽기 쉬운 콘솔 출력 -->
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <!-- 운영 환경: JSON 구조화 로깅 -->
+        <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>requestUri</includeMdcKeyName>
+                <timeZone>Asia/Seoul</timeZone>
+                <fieldNames>
+                    <timestamp>@timestamp</timestamp>
+                    <version>[ignore]</version>
+                </fieldNames>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="JSON_CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/test/java/com/mvp/v1/dandionna/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mvp/v1/dandionna/auth/service/AuthServiceTest.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,19 +25,15 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.mvp.v1.dandionna.auth.dto.LoginRequest;
 import com.mvp.v1.dandionna.auth.dto.LoginResponse;
-import com.mvp.v1.dandionna.auth.dto.LogoutRequest;
-import com.mvp.v1.dandionna.auth.dto.RefreshTokenRequest;
-import com.mvp.v1.dandionna.auth.dto.RefreshTokenResponse;
 import com.mvp.v1.dandionna.auth.dto.SignUpRequest;
 import com.mvp.v1.dandionna.auth.entity.User;
 import com.mvp.v1.dandionna.auth.entity.UserRole;
 import com.mvp.v1.dandionna.auth.repository.UserRepository;
 import com.mvp.v1.dandionna.common.exeption.BusinessException;
-import com.mvp.v1.dandionna.config.Security.JwtProps;
 import com.mvp.v1.dandionna.config.Security.JweTokenService;
-import com.mvp.v1.dandionna.auth.service.TokenBlacklistService;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -61,7 +56,6 @@ class AuthServiceTest {
 
 	@Test
 	void 로그인_성공() {
-		// given: 가입된 사용자와 토큰 발급 결과를 가짜로 구성
 		LoginRequest request = new LoginRequest("user1", "plain");
 		User user = createUser("user1", UserRole.CONSUMER, "encoded");
 
@@ -70,64 +64,78 @@ class AuthServiceTest {
 		when(tokenService.issueAccessToken(any(), any())).thenReturn("access-token");
 		when(tokenService.issueRefreshToken(any())).thenReturn("refresh-token");
 
-		// when: 로그인 서비스 호출
 		LoginResponse response = authService.login(request);
 
-		// then: 액세스/리프레시 토큰이 기대값으로 내려오는지 검증
 		assertThat(response.accessToken()).isEqualTo("access-token");
 		assertThat(response.refreshToken()).isEqualTo("refresh-token");
 	}
 
 	@Test
 	void 로그인_비밀번호_오류() {
-		// given: 아이디는 존재하지만 비밀번호가 일치하지 않는 상황
 		LoginRequest request = new LoginRequest("user1", "plain");
 		User user = createUser("user1", UserRole.CONSUMER, "encoded");
 		when(userRepository.findByLoginId("user1")).thenReturn(Optional.of(user));
 		when(passwordEncoder.matches("plain", "encoded")).thenReturn(false);
 
-		// then: BusinessException 이 발생해야 한다
+		assertThatThrownBy(() -> authService.login(request))
+			.isInstanceOf(BusinessException.class);
+	}
+
+	@Test
+	void 로그인_존재하지_않는_사용자() {
+		LoginRequest request = new LoginRequest("unknown", "plain");
+		when(userRepository.findByLoginId("unknown")).thenReturn(Optional.empty());
+
 		assertThatThrownBy(() -> authService.login(request))
 			.isInstanceOf(BusinessException.class);
 	}
 
 	@Test
 	void 회원가입_중복_예외() {
-		// given: 동일한 loginId 가 이미 존재
 		SignUpRequest request = new SignUpRequest("user1", "plain", UserRole.CONSUMER);
 		when(userRepository.existsByLoginId("user1")).thenReturn(true);
 
-		// then: 중복 예외 발생
 		assertThatThrownBy(() -> authService.signUp(request))
 			.isInstanceOf(BusinessException.class);
 	}
 
 	@Test
-	void 로그아웃_블랙리스트_등록() {
-		// given: 두 토큰이 모두 유효하고 남은 TTL 을 계산할 수 있음
+	void 로그아웃_원자적_블랙리스트_등록() {
 		String accessToken = "access";
 		String refreshToken = "refresh";
-		LogoutRequest request = new LogoutRequest(refreshToken);
 
 		Claims accessClaims = claimsWithExpiration(Instant.now().plusSeconds(60));
 		Claims refreshClaims = claimsWithExpiration(Instant.now().plusSeconds(120));
 		when(tokenService.parseClaims(accessToken)).thenReturn(accessClaims);
 		when(tokenService.parseClaims(refreshToken)).thenReturn(refreshClaims);
 
-		// when: 로그아웃 수행
-		authService.logout(accessToken, request);
+		authService.logout(accessToken, refreshToken);
 
-		// then: access/refresh 모두 블랙리스트에 등록 요청
-		verify(blacklistService).blacklistAccessToken(eq(accessToken), any(Duration.class));
+		verify(blacklistService).blacklistBoth(
+			eq(accessToken), any(Duration.class),
+			eq(refreshToken), any(Duration.class)
+		);
+	}
+
+	@Test
+	void 로그아웃_만료된_액세스_토큰일_때_리프레시만_블랙리스트() {
+		String accessToken = "expired-access";
+		String refreshToken = "refresh";
+
+		when(tokenService.parseClaims(accessToken)).thenThrow(new JwtException("expired"));
+		Claims refreshClaims = claimsWithExpiration(Instant.now().plusSeconds(120));
+		when(tokenService.parseClaims(refreshToken)).thenReturn(refreshClaims);
+
+		authService.logout(accessToken, refreshToken);
+
+		verify(blacklistService, never()).blacklistBoth(any(), any(), any(), any());
 		verify(blacklistService).blacklistRefreshToken(eq(refreshToken), any(Duration.class));
 	}
 
 	@Test
 	void 토큰_재발급_성공() {
-		// given: 블랙리스트에 없는 refresh 토큰과 사용자
 		String refreshToken = "refresh";
 		UUID userId = UUID.randomUUID();
-		RefreshTokenRequest request = new RefreshTokenRequest(refreshToken);
 
 		Claims claims = claimsWithExpiration(Instant.now().plusSeconds(3600));
 		when(claims.get("typ")).thenReturn("refresh");
@@ -141,25 +149,34 @@ class AuthServiceTest {
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 		when(tokenService.issueAccessToken(any(), any())).thenReturn("new-access");
 
-		// when
-		RefreshTokenResponse response = authService.refresh(request);
+		String result = authService.refresh(refreshToken);
 
-		// then: 신규 토큰이 발급되고 기존 refresh 토큰은 블랙리스트 처리
-		assertThat(response.accessToken()).isEqualTo("new-access");
+		assertThat(result).isEqualTo("new-access");
 	}
 
 	@Test
 	void 토큰_재발급_블랙리스트이면_예외() {
-		// given: 이미 블랙리스트에 올라간 refresh 토큰
 		String refreshToken = "blocked";
-		RefreshTokenRequest request = new RefreshTokenRequest(refreshToken);
 		when(blacklistService.isRefreshTokenBlacklisted(refreshToken)).thenReturn(true);
 
-		// then: 예외 발생 및 신규 토큰 발급 로직은 호출되지 않음
-		assertThatThrownBy(() -> authService.refresh(request))
+		assertThatThrownBy(() -> authService.refresh(refreshToken))
 			.isInstanceOf(BusinessException.class);
 
 		verify(tokenService, never()).issueAccessToken(any(), any());
+	}
+
+	@Test
+	void 토큰_재발급_리프레시_아닌_토큰_예외() {
+		String accessToken = "access-token-not-refresh";
+
+		Claims claims = claimsWithExpiration(Instant.now().plusSeconds(3600));
+		when(claims.get("typ")).thenReturn("access");
+
+		when(blacklistService.isRefreshTokenBlacklisted(accessToken)).thenReturn(false);
+		when(tokenService.parseClaims(accessToken)).thenReturn(claims);
+
+		assertThatThrownBy(() -> authService.refresh(accessToken))
+			.isInstanceOf(BusinessException.class);
 	}
 
 	private User createUser(String loginId, UserRole role, String passwordHash) {

--- a/src/test/java/com/mvp/v1/dandionna/config/Security/RateLimitFilterTest.java
+++ b/src/test/java/com/mvp/v1/dandionna/config/Security/RateLimitFilterTest.java
@@ -1,0 +1,100 @@
+package com.mvp.v1.dandionna.config.Security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimitFilterTest {
+
+	@Mock
+	private StringRedisTemplate redisTemplate;
+	@Mock
+	private ValueOperations<String, String> valueOps;
+
+	private RateLimitFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		RateLimitProperties props = new RateLimitProperties(5, 100, 3);
+		filter = new RateLimitFilter(redisTemplate, props);
+		when(redisTemplate.opsForValue()).thenReturn(valueOps);
+	}
+
+	@Test
+	void 제한_내_요청은_통과() throws Exception {
+		when(valueOps.increment(anyString())).thenReturn(1L);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+		request.setRemoteAddr("127.0.0.1");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, new MockFilterChain());
+
+		assertThat(response.getStatus()).isEqualTo(200);
+	}
+
+	@Test
+	void 제한_초과_요청은_429() throws Exception {
+		when(valueOps.increment(anyString())).thenReturn(6L); // 5회 제한 초과
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+		request.setRemoteAddr("127.0.0.1");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, new MockFilterChain());
+
+		assertThat(response.getStatus()).isEqualTo(429);
+		assertThat(response.getHeader("Retry-After")).isEqualTo("60");
+	}
+
+	@Test
+	void Redis_장애_시_요청_통과() throws Exception {
+		when(valueOps.increment(anyString())).thenThrow(new RuntimeException("Redis down"));
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/stores");
+		request.setRemoteAddr("127.0.0.1");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, new MockFilterChain());
+
+		assertThat(response.getStatus()).isEqualTo(200);
+	}
+
+	@Test
+	void Actuator_경로는_제한_없음() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/actuator/health");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, new MockFilterChain());
+
+		assertThat(response.getStatus()).isEqualTo(200);
+	}
+
+	@Test
+	void X_Forwarded_For_헤더로_클라이언트_IP_판별() throws Exception {
+		when(valueOps.increment(anyString())).thenReturn(1L);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+		request.setRemoteAddr("10.0.0.1");
+		request.addHeader("X-Forwarded-For", "203.0.113.50, 10.0.0.1");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, new MockFilterChain());
+
+		assertThat(response.getStatus()).isEqualTo(200);
+	}
+}

--- a/src/test/java/com/mvp/v1/dandionna/noshow_post/service/PostExpirySchedulerTest.java
+++ b/src/test/java/com/mvp/v1/dandionna/noshow_post/service/PostExpirySchedulerTest.java
@@ -1,0 +1,56 @@
+package com.mvp.v1.dandionna.noshow_post.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.mvp.v1.dandionna.noshow_post.entity.NoShowPost;
+import com.mvp.v1.dandionna.noshow_post.entity.NoShowPostStatus;
+import com.mvp.v1.dandionna.noshow_post.repository.NoShowPostRepository;
+
+import io.micrometer.core.instrument.Counter;
+
+@ExtendWith(MockitoExtension.class)
+class PostExpirySchedulerTest {
+
+	@Mock
+	private NoShowPostRepository noShowPostRepository;
+	@Mock
+	private Counter postExpiredCounter;
+
+	@InjectMocks
+	private PostExpiryScheduler scheduler;
+
+	@Test
+	void 만료_게시글_있으면_markExpired_호출() {
+		NoShowPost post = org.mockito.Mockito.mock(NoShowPost.class);
+		when(noShowPostRepository.findExpiredPosts(eq(NoShowPostStatus.open), any()))
+			.thenReturn(List.of(post));
+
+		scheduler.expirePosts();
+
+		verify(post).markExpired();
+		verify(postExpiredCounter).increment(1);
+	}
+
+	@Test
+	void 만료_게시글_없으면_아무것도_안함() {
+		when(noShowPostRepository.findExpiredPosts(eq(NoShowPostStatus.open), any()))
+			.thenReturn(Collections.emptyList());
+
+		scheduler.expirePosts();
+
+		verify(postExpiredCounter, never()).increment(any(double.class));
+	}
+}

--- a/src/test/java/com/mvp/v1/dandionna/notification/worker/NotificationDispatchWorkerTest.java
+++ b/src/test/java/com/mvp/v1/dandionna/notification/worker/NotificationDispatchWorkerTest.java
@@ -1,0 +1,94 @@
+package com.mvp.v1.dandionna.notification.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.mvp.v1.dandionna.fcm.service.FcmNotificationService;
+import com.mvp.v1.dandionna.notification.repository.NotificationTargetRepository;
+
+import io.micrometer.core.instrument.Counter;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationDispatchWorkerTest {
+
+	@Mock private StringRedisTemplate redisTemplate;
+	@Mock private StreamOperations<String, Object, Object> streamOps;
+	@Mock private FcmNotificationService fcmService;
+	@Mock private NotificationTargetRepository targetRepository;
+	@Mock private Counter sentCounter;
+	@Mock private Counter failedCounter;
+
+	private NotificationDispatchWorker worker;
+
+	@BeforeEach
+	void setUp() {
+		lenient().when(redisTemplate.opsForStream()).thenReturn(streamOps);
+		// ensureGroup 에서 createGroup 호출 시 이미 존재할 수 있으므로 무시
+		lenient().when(streamOps.createGroup(anyString(), anyString())).thenReturn("OK");
+		worker = new NotificationDispatchWorker(redisTemplate, fcmService, targetRepository, sentCounter, failedCounter);
+	}
+
+	@Test
+	void DLQ_크기_조회_스트림_없으면_0() {
+		when(streamOps.size("notification:dlq")).thenReturn(null);
+
+		long size = worker.getDlqSize();
+
+		assertThat(size).isEqualTo(0);
+	}
+
+	@Test
+	void DLQ_크기_조회_정상() {
+		when(streamOps.size("notification:dlq")).thenReturn(5L);
+
+		long size = worker.getDlqSize();
+
+		assertThat(size).isEqualTo(5);
+	}
+
+	@Test
+	void DLQ_재처리_비어있으면_0반환() {
+		when(streamOps.read(any(org.springframework.data.redis.connection.stream.StreamOffset.class)))
+			.thenReturn(Collections.emptyList());
+
+		int result = worker.replayDlq(10);
+
+		assertThat(result).isEqualTo(0);
+	}
+
+	@Test
+	void processOnce_빈_스트림이면_즉시_리턴() {
+		when(streamOps.read(
+			any(org.springframework.data.redis.connection.stream.Consumer.class),
+			any(org.springframework.data.redis.connection.stream.StreamReadOptions.class),
+			any(org.springframework.data.redis.connection.stream.StreamOffset.class)
+		)).thenReturn(null);
+
+		worker.processOnce();
+
+		verify(sentCounter, never()).increment();
+		verify(failedCounter, never()).increment();
+	}
+}


### PR DESCRIPTION
## 요약

dandi-onna-be 백엔드 아키텍처 분석을 기반으로 한 5단계 개선 작업입니다.

### Phase 1: 보안 강화
- **CORS 화이트리스트 외부 설정화** 및 보안 헤더(HSTS, X-Frame-Options 등) 추가
- **Redis 기반 Rate Limiting**: 로그인 5회/분, API 100회/분, Export 3회/시간

### Phase 2: 인가 체계 정비
- 전체 컨트롤러에 **@PreAuthorize 메서드 레벨 인가** 도입 (OWNER/CONSUMER/ADMIN)
- **ADMIN 역할 활성화** 및 관리자 전용 API (사용자/매장 목록 조회)

### Phase 3: 토큰 보안 강화
- **JWE 키 로테이션** (kid 헤더 + 이전 키 폴백)
- **Lua 스크립트 원자적 토큰 폐기** (Access+Refresh 동시 블랙리스트)
- **Refresh Token → HttpOnly Cookie** (하위 호환 유지)

### Phase 4: 운영 안정성
- **만료 게시글 자동 스케줄러** (1분 주기) + **S3 고아 객체 정리** (매일 03시)
- **알림 DLQ 스트림** (3회 재시도 초과 → notification:dlq) + **알림 이력 조회 API**

### Phase 5: 관측 가능성 & 품질
- **Micrometer + Prometheus** 연동 (주문/알림/만료 비즈니스 메트릭)
- **JSON 구조화 로깅** (logstash-logback-encoder + MDC 요청 추적)
- **DTO Validation 통일** (누락 검증 보완)
- **단위 테스트 보강** (AuthService, RateLimitFilter, PostExpiryScheduler, DLQ Worker)

## 커밋 목록 (11개)
| 커밋 | 내용 |
|------|------|
| e94d13c | [Phase 1-1,1-2] CORS 화이트리스트 + 보안 헤더 |
| f49b817 | [Phase 1-3] Redis Rate Limiting |
| 6b8e008 | [Phase 2-1,2-2] @PreAuthorize 메서드 인가 |
| f13f55d | [Phase 2-3] ADMIN 역할 + 관리자 API |
| 7ce5701 | [Phase 3] 키 로테이션, 원자적 폐기, HttpOnly Cookie |
| ce70c33 | [Phase 4-1,4-2] 만료 스케줄러 + S3 정리 |
| 709f2ab | [Phase 4-3,4-4] 알림 DLQ + 이력 API |
| 6a99800 | [Phase 5-1] Prometheus 연동 |
| 4bd8d2e | [Phase 5-2] 구조화 로깅 + MDC |
| 53be9dd | [Phase 5-3] DTO Validation 통일 |
| 1a95623 | [Phase 5-4] 단위 테스트 보강 |

## 테스트 계획
- [ ] 로컬 환경에서 빌드 성공 확인 (`./gradlew build`)
- [ ] 단위 테스트 통과 확인 (`./gradlew test`)
- [ ] Rate Limiting 동작 확인 (로그인 6회 연속 시 429 응답)
- [ ] Actuator 엔드포인트 접근 확인 (`/actuator/prometheus`, `/actuator/health`)
- [ ] Refresh Token 쿠키 설정 확인 (Set-Cookie 헤더)
- [ ] 관리자 API 접근 제어 확인 (ADMIN 외 403)
- [ ] 알림 이력 API 조회 확인 (`GET /api/v1/notifications`)
