### PR TITLE
docs: 포트폴리오 공개 기준선 main 승격 (#46)

### DIFF
--- a/PORTFOLIO.md
+++ b/PORTFOLIO.md
@@ -1,8 +1,10 @@
 # Dandi-Onna - 노쇼 재고 손실을 판매 기회로 전환하는 O2O 예약·주문 플랫폼
 
 > - 이 문서는 단디온나 백엔드에서 담당한 구현 범위와 기술적 기여를 정리한 문서입니다.
-> - 기준 브랜치 `feat/38-menu-domain-expansion`
-> - 문서 브랜치 `docs/dandi-onna-portfolio`
+> - 공식 기준 브랜치 `main`
+> - 개발 통합 브랜치 `develop`
+> - 검증 기준 태그 `portfolio-baseline-2026-07`
+> - 최종 기준선 검증일 `2026-07-20`
 
 ## 1. 프로젝트 개요
 
@@ -16,7 +18,8 @@
 | 팀명 | TEAM Ynot? |
 | 역할 | 백엔드 단독 개발자 |
 | 주요 담당 | 인증/인가, 매장/메뉴, 노쇼 게시글, 예약 게시, 주문, 알림, 매출 조회·엑셀 export, 운영/성능 측정 |
-| 기준 브랜치 | `feat/38-menu-domain-expansion` |
+| 공식 기준선 | `main` / `portfolio-baseline-2026-07` |
+| 개발 통합 브랜치 | `develop` |
 | Repository | https://github.com/goorm-ynot/dandi-onna-be |
 
 ## 2. 담당 역할 요약

--- a/README.md
+++ b/README.md
@@ -102,33 +102,38 @@ export MINIO_SECRET_KEY=change-me
 성능 측정은 `k6 + Docker` 기준으로 통일되어 있습니다. 자세한 기준과 해석 방법은 [doc/performance-measurement-plan.md](doc/performance-measurement-plan.md)를 기준 문서로 사용합니다.
 
 ```bash
-# 1) 성능 측정용 env 준비
-cd /home/rua/Project/dandi/v1/dandi-onna-be
+# 1) 백엔드 저장소 준비
+git clone https://github.com/goorm-ynot/dandi-onna-be.git
+cd dandi-onna-be
+export DANDI_BACKEND_DIR="$PWD"
+
+# 2) 성능 측정용 env 준비
 cp env/perf.local.env.example env/perf.local.env
 
-# 2) env/perf.local.env 값을 현재 머신 기준으로 수정
+# 3) env/perf.local.env 값을 현재 머신 기준으로 수정
 #    - DATABASE/REDIS/MINIO/JWE/FIREBASE 경로
 #    - SERVER_PORT=18080
 #    - MINIO_PUBLIC_ENDPOINT=http://host.docker.internal:19090
 
-# 3) Infra 실행
-cd /home/rua/Project/dandi/Infra
+# 4) 별도 Infra 저장소 실행
+export DANDI_INFRA_DIR=/path/to/dandi-infra
+cd "$DANDI_INFRA_DIR"
 ./infra.sh start
 
-# 4) 앱 실행
-cd /home/rua/Project/dandi/v1/dandi-onna-be
+# 5) 앱 실행
+cd "$DANDI_BACKEND_DIR"
 ./scripts/perf/run-app.sh
 
-# 5) 상태 확인
+# 6) 상태 확인
 ./scripts/perf/check-stack.sh
 
-# 6) 벤치마크용 데이터셋 적용
+# 7) 벤치마크용 데이터셋 적용
 ./scripts/perf/apply-seed.sh small
 
-# 7) 필수 smoke 실행
+# 8) 필수 smoke 실행
 ./scripts/perf/run-required.sh smoke
 
-# 8) 필수 measure 실행
+# 9) 필수 measure 실행
 ./scripts/perf/run-required.sh measure
 ```
 
@@ -159,10 +164,10 @@ cd /home/rua/Project/dandi/v1/dandi-onna-be
 
 ## 테스트
 
-기준 브랜치에서 다음 테스트 결과를 확인했습니다.
+공식 기준 브랜치 `main`과 포트폴리오 태그 `portfolio-baseline-2026-07`에서 다음 테스트 결과를 확인했습니다.
 
 ```text
-./gradlew test --no-daemon
+./gradlew clean test bootJar --no-daemon --console=plain
 59 tests, 0 failures, 0 errors, 2 skipped
 ```
 

--- a/doc/performance-measurement-plan.md
+++ b/doc/performance-measurement-plan.md
@@ -69,10 +69,11 @@
 
 ### 4-1. Infra
 
-인프라 루트는 `/home/rua/Project/dandi/Infra` 이다.
+PostgreSQL, Redis, MinIO와 관측 도구는 별도 Infra 저장소를 사용한다. 로컬 경로를 고정하지 않고 환경변수로 지정한다.
 
 ```bash
-cd /home/rua/Project/dandi/Infra
+export DANDI_INFRA_DIR=/path/to/dandi-infra
+cd "$DANDI_INFRA_DIR"
 ./infra.sh start
 ```
 
@@ -88,7 +89,9 @@ cd /home/rua/Project/dandi/Infra
 앱은 Docker가 아니라 호스트에서 실행한다. Docker는 Infra 와 k6 실행에만 사용한다.
 
 ```bash
-cd /home/rua/Project/dandi/v1/dandi-onna-be
+git clone https://github.com/goorm-ynot/dandi-onna-be.git
+cd dandi-onna-be
+export DANDI_BACKEND_DIR="$PWD"
 cp env/perf.local.env.example env/perf.local.env
 
 # env/perf.local.env 수정

--- a/doc/project-log.md
+++ b/doc/project-log.md
@@ -11,6 +11,11 @@
 - `CONTRIBUTING.md`와 PR 템플릿에 이슈·브랜치·커밋·검증·병합 공식 규칙 추가
 
 ### Changed
+- PR #45를 merge commit 방식으로 병합해 `main`과 `develop` 계보를 연결하고 동일 tree 기준선을 확립
+- `main` ruleset에 PR, `build`/`test`, 최신 base 검사, review thread 해결, merge commit 전용 병합, force push·삭제 차단 적용
+- 이슈 #46에서 과거 원격 브랜치 19개의 tip SHA와 통합 근거를 감사한 뒤 원격 브랜치를 `main`, `develop`으로 정리
+- `PORTFOLIO.md`와 저장소 문서의 공식 기준을 `main`, `develop`, `portfolio-baseline-2026-07` 태그로 통일
+- README와 성능 측정 문서의 개인 로컬 절대경로를 재사용 가능한 환경변수 기반 예시로 일반화
 - Gradle 로컬 wrapper 다운로드 캐시를 Git 추적에서 제거하고 `.gradle-local/` ignore 규칙 추가
 - 메뉴 이미지 업로드 토큰 검증 실패 시 Redis 잠금을 즉시 해제하도록 보완
 - 현재 구현에 맞춰 메뉴 이미지 임시 업로드 컨트롤러와 API 경로를 아키텍처 문서에 반영

--- a/doc/repo-notes.md
+++ b/doc/repo-notes.md
@@ -6,12 +6,13 @@
 
 | 구분 | 내용 |
 |---|---|
-| 기준 구현 브랜치 | `feat/38-menu-domain-expansion` |
-| 문서 브랜치 | `docs/dandi-onna-portfolio` |
-| 기본 브랜치 | `main` |
+| 공식 기준 브랜치 | `main` |
+| 개발 통합 브랜치 | `develop` |
+| 검증 기준 태그 | `portfolio-baseline-2026-07` |
+| 최종 기준선 검증일 | `2026-07-20` |
 | 저장소 | `goorm-ynot/dandi-onna-be` |
 
-`docs/dandi-onna-portfolio` 브랜치는 `feat/38-menu-domain-expansion`의 구현 상태를 기준으로 문서화했습니다.
+`main`은 공개·포트폴리오 기준선이고 `develop`은 후속 개발 통합 브랜치입니다. `portfolio-baseline-2026-07` 태그는 이 문서 정리까지 반영된 최종 `main`을 고정합니다.
 
 ## 2. 프로젝트 기간 기준
 
@@ -62,14 +63,14 @@
 
 ## 5. 주요 커밋
 
-기준 브랜치에서 문서화 근거로 사용한 최근 주요 커밋입니다.
+현재 기준선 형성에 사용한 최근 주요 커밋입니다.
 
 ```text
-9dfe327 설정: CORS 및 인프라 테스트 조건 정리
-cd963c2 기능: 메뉴 도메인 확장 및 노쇼 게시 연동 정리
-d0a8e8c 개선: 비동기 워커 종료 처리 안정화
-2becd24 기능: 날짜 파싱 및 매출 내보내기 기준 정리
-924745c 문서: 운영 및 성능 측정 실행 자산 정리
+7a2eb61 main과 develop 계보 정합화 및 main 기준선 형성 (#45)
+bf853ad Gradle 로컬 캐시 추적 제거 (#43)
+889b8c8 feat/38·feat/39 및 문서 작업 복구 통합 (#41)
+7b3e724 보안·인가·토큰·운영·관측 리팩터링 (#36)
+ec78594 AS-IS/TO-BE 아키텍처 시각화 문서 추가 (#35)
 ```
 
 ## 6. 검토 순서
@@ -95,10 +96,10 @@ d0a8e8c 개선: 비동기 워커 종료 처리 안정화
 
 ## 7. 테스트 기준
 
-기준 브랜치에서 다음 테스트 결과를 확인했습니다.
+공식 기준 브랜치와 포트폴리오 태그에서 다음 테스트 결과를 확인했습니다.
 
 ```text
-./gradlew test --no-daemon
+./gradlew clean test bootJar --no-daemon --console=plain
 59 tests, 0 failures, 0 errors, 2 skipped
 ```
 


### PR DESCRIPTION
## 변경 이유

PR #47에서 검증하고 `develop`에 squash 병합한 공개 저장소 문서 기준선을 `main`에 승격합니다. 이번 승격이 완료되면 공개 첫 화면과 포트폴리오 문서가 `main`, `develop`, `portfolio-baseline-2026-07` 기준으로 일관되게 표시됩니다.

Closes #46

## 승격 범위

`origin/main`과 `origin/develop`의 파일 차이를 확인했으며 아래 다섯 문서만 변경됩니다.

- `PORTFOLIO.md`
- `README.md`
- `doc/performance-measurement-plan.md`
- `doc/project-log.md`
- `doc/repo-notes.md`

애플리케이션 코드, dependency, DB migration, 런타임 설정은 변경하지 않습니다.

## 주요 내용

이전 `feat/38-menu-domain-expansion`, `docs/dandi-onna-portfolio` 기준을 제거하고 공식 기준 브랜치를 `main`, 개발 통합 브랜치를 `develop`, 포트폴리오 기준을 `portfolio-baseline-2026-07` 태그로 통일합니다.

개인 로컬 절대경로를 제거하고 저장소 clone 및 `DANDI_BACKEND_DIR`, `DANDI_INFRA_DIR` 환경변수 기반 예시로 일반화합니다.

과거 원격 브랜치 19개의 tip SHA와 통합 근거는 이슈 #46에 기록했고, 현재 원격에는 `main`, `develop`과 이 승격에 필요한 기준 브랜치만 존재합니다.

## 검증 결과

PR #47 head와 로컬에서 Java 21 기준 다음 검증을 통과했습니다.

```bash
./gradlew clean test bootJar --no-daemon --console=plain
```

- 테스트 59개, 실패·오류 0개, 외부 인프라 조건 테스트 2개 제외
- GitHub Actions `build`, `test` 성공
- Markdown 상대 링크 13개, 누락 0개
- 개인 경로와 이전 기준 브랜치명 0건
- `git diff --check origin/main origin/develop` 통과

## 병합 조건

`main`의 승격 계보를 유지하기 위해 반드시 **Create a merge commit** 방식으로 병합합니다. Squash 또는 rebase를 사용하지 않습니다.

병합 후 최종 `main`을 다시 검증한 다음 annotated tag `portfolio-baseline-2026-07`을 생성합니다.

## 보안·데이터·배포

비밀정보와 `.aipf/skip.json`은 포함하지 않습니다. 실제 PostgreSQL, Redis, S3/MinIO, Firebase에 연결하지 않았고 운영 데이터 변경과 배포를 수행하지 않습니다.

## 롤백

병합 전에는 PR을 닫을 수 있습니다. 병합 후 문제가 있으면 force push나 계보 재작성 없이 별도 revert PR로 문서 변경만 되돌립니다.